### PR TITLE
feat: automatically redirect all apps to default device when changed

### DIFF
--- a/FineTune/Audio/AudioEngine.swift
+++ b/FineTune/Audio/AudioEngine.swift
@@ -168,6 +168,12 @@ final class AudioEngine {
             ensureTapExists(for: app, deviceUID: deviceUID)
         }
     }
+    
+    func setDeviceForAllApps(_ deviceUID: String) {
+        apps.forEach { app in
+            setDevice(for: app, deviceUID: deviceUID)
+        }
+    }
 
     func getDeviceUID(for app: AudioApp) -> String? {
         appDeviceRouting[app.id]

--- a/FineTune/Views/MenuBarPopupView.swift
+++ b/FineTune/Views/MenuBarPopupView.swift
@@ -107,6 +107,7 @@ struct MenuBarPopupView: View {
                     isMuted: deviceVolumeMonitor.muteStates[device.id] ?? false,
                     onSetDefault: {
                         deviceVolumeMonitor.setDefaultDevice(device.id)
+                        audioEngine.setDeviceForAllApps(device.uid)
                     },
                     onVolumeChange: { volume in
                         deviceVolumeMonitor.setVolume(for: device.id, to: volume)


### PR DESCRIPTION
Implement logic to update the output device for all running applications when the system default changes. This ensures consistent audio routing across the entire system without manual per-app configuration.

- Added `setDeviceForAllApps` to iterate through active sessions.
- Linked system default change events to the redirection logic.