### PR TITLE
feat: automatically redirect all apps to default device when changed

### DIFF
--- a/FineTune/Audio/AudioEngine.swift
+++ b/FineTune/Audio/AudioEngine.swift
@@ -58,6 +58,10 @@ final class AudioEngine {
                     }
                 }
             }
+            
+            deviceVolumeMonitor.onDefaultDeviceChanged = { [weak self] deviceUID in
+                self?.setDeviceForAllApps(deviceUID)
+            }
 
             processMonitor.onAppsChanged = { [weak self] _ in
                 self?.cleanupStaleTaps()
@@ -67,7 +71,7 @@ final class AudioEngine {
             deviceMonitor.onDeviceDisconnected = { [weak self] deviceUID, deviceName in
                 self?.handleDeviceDisconnected(deviceUID, name: deviceName)
             }
-
+            
             applyPersistedSettings()
         }
     }
@@ -166,6 +170,12 @@ final class AudioEngine {
             }
         } else {
             ensureTapExists(for: app, deviceUID: deviceUID)
+        }
+    }
+    
+    func setDeviceForAllApps(_ deviceUID: String) {
+        apps.forEach { app in
+            setDevice(for: app, deviceUID: deviceUID)
         }
     }
 

--- a/FineTune/Audio/DeviceVolumeMonitor.swift
+++ b/FineTune/Audio/DeviceVolumeMonitor.swift
@@ -23,6 +23,9 @@ final class DeviceVolumeMonitor {
 
     /// Called when any device's mute state changes (deviceID, isMuted)
     var onMuteChanged: ((AudioDeviceID, Bool) -> Void)?
+    
+    /// Called when default device changed (String)
+    var onDefaultDeviceChanged: ((String) -> Void)?
 
     private let deviceMonitor: AudioDeviceMonitor
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "FineTune", category: "DeviceVolumeMonitor")
@@ -174,6 +177,11 @@ final class DeviceVolumeMonitor {
             if newDeviceID.isValid {
                 defaultDeviceID = newDeviceID
                 defaultDeviceUID = try? newDeviceID.readDeviceUID()
+                
+                if let newDefaultDeviceUid = defaultDeviceUID {
+                    onDefaultDeviceChanged?(newDefaultDeviceUid)
+                }
+                
                 logger.debug("Default device ID: \(self.defaultDeviceID), UID: \(self.defaultDeviceUID ?? "nil")")
             } else {
                 logger.warning("Default output device is invalid")


### PR DESCRIPTION
Implement logic to update the output device for all running applications when the system default changes. This ensures consistent audio routing across the entire system without manual per-app configuration.

- Added `setDeviceForAllApps` to iterate through active sessions.
- Linked system default change events to the redirection logic.