### PR TITLE
feat: add editable volume text field in AppRow

### DIFF
--- a/FineTune/Views/Rows/AppRow.swift
+++ b/FineTune/Views/Rows/AppRow.swift
@@ -176,6 +176,11 @@ struct AppRow: View {
                                     isEditingVolumeTextVisible = false
                                 }
                             }
+                            .onExitCommand {
+                                volumeText = "\(Int((sliderValue * 200).rounded()))"
+                                isEditingVolumeText = false
+                                isEditingVolumeTextVisible = false
+                            }
                     } else {
                         Text("\(Int((sliderValue * 200).rounded()))%")
                             .percentageStyle()


### PR DESCRIPTION
# What this PR does

- Implement an editable text field for app volumes

_Note: it is my first time using Swift so there might be some coding practices issues related to this programming language. I'd appreciate any feedback code-wise!_

Screenshots:

<img width="607" height="297" alt="Screenshot 2026-01-23 at 20 50 56" src="https://github.com/user-attachments/assets/d50c94fa-b5a9-477f-b08a-2d0b86d5adce" />

<img width="599" height="284" alt="Screenshot 2026-01-23 at 20 51 04" src="https://github.com/user-attachments/assets/d18718ca-037b-4fb2-9d65-61c30ea23a7c" />
