### PR TITLE
fix(RadioButton): fix selected device icon

### DIFF
--- a/FineTune/Views/Components/RadioButton.swift
+++ b/FineTune/Views/Components/RadioButton.swift
@@ -10,7 +10,7 @@ struct RadioButton: View {
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+            Image(systemName: isSelected ? "inset.filled.circle" : "circle")
                 .font(.system(size: 14))
                 .symbolRenderingMode(isSelected ? .monochrome : .hierarchical)
                 .foregroundStyle(isSelected ? DesignTokens.Colors.defaultDevice : buttonColor)


### PR DESCRIPTION
Before:
<img width="580" height="312" alt="image" src="https://github.com/user-attachments/assets/60e208e4-22eb-4005-b3fd-497ef8865dd1" />

After:
<img width="580" height="312" alt="image" src="https://github.com/user-attachments/assets/520ba983-1613-44bf-be11-9a9b20c2f4ca" />

Based on a comment on reddit: 

> Free designer tip: don't use check boxes where you can use radio buttons