### PR TITLE
feat(settings): add option to control default EQ state for new apps

### DIFF
--- a/FineTune/Settings/SettingsManager.swift
+++ b/FineTune/Settings/SettingsManager.swift
@@ -47,6 +47,7 @@ struct AppSettings: Codable, Equatable {
     // Audio
     var defaultNewAppVolume: Float = 1.0      // 100% (unity gain)
     var maxVolumeBoost: Float = 2.0           // 200% max
+    var defaultEQEnabled: Bool = true         // Whether EQ is enabled by default for new apps
 
     // Input Device Lock
     var lockInputDevice: Bool = true          // Prevent auto-switching input device
@@ -139,7 +140,11 @@ final class SettingsManager {
     }
 
     func getEQSettings(for appIdentifier: String) -> EQSettings {
-        return settings.appEQSettings[appIdentifier] ?? EQSettings.flat
+        if let savedSettings = settings.appEQSettings[appIdentifier] {
+            return savedSettings
+        }
+        // Return default EQ with isEnabled based on user preference
+        return EQSettings(isEnabled: settings.appSettings.defaultEQEnabled)
     }
 
     func setEQSettings(_ eqSettings: EQSettings, for appIdentifier: String) {

--- a/FineTune/Views/Settings/SettingsView.swift
+++ b/FineTune/Views/Settings/SettingsView.swift
@@ -85,6 +85,13 @@ struct SettingsView: View {
             )
 
             SettingsToggleRow(
+                icon: "slider.vertical.3",
+                title: "Enable EQ by Default",
+                description: "Automatically enable equalizer for new apps",
+                isOn: $settings.defaultEQEnabled
+            )
+
+            SettingsToggleRow(
                 icon: "mic",
                 title: "Lock Input Device",
                 description: "Prevent auto-switching when devices connect",


### PR DESCRIPTION
Add a new "Enable EQ by Default" toggle in Settings > Audio that allows users to choose whether EQ is enabled or disabled for newly discovered applications. The default remains enabled (preserving existing behavior).