### PR TITLE
Add help tooltips for device/app names.

### DIFF
--- a/FineTune/Views/Rows/AppRow.swift
+++ b/FineTune/Views/Rows/AppRow.swift
@@ -149,6 +149,7 @@ struct AppRow: View {
                 Text(app.name)
                     .font(DesignTokens.Typography.rowName)
                     .lineLimit(1)
+                    .help(app.name)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 // Shared controls section

--- a/FineTune/Views/Rows/DeviceRow.swift
+++ b/FineTune/Views/Rows/DeviceRow.swift
@@ -63,6 +63,7 @@ struct DeviceRow: View {
             Text(device.name)
                 .font(isDefault ? DesignTokens.Typography.rowNameBold : DesignTokens.Typography.rowName)
                 .lineLimit(1)
+                .help(device.name)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
             // Mute button

--- a/FineTune/Views/Rows/InactiveAppRow.swift
+++ b/FineTune/Views/Rows/InactiveAppRow.swift
@@ -128,6 +128,7 @@ struct InactiveAppRow: View {
                 Text(appInfo.displayName)
                     .font(DesignTokens.Typography.rowName)
                     .lineLimit(1)
+                    .help(appInfo.displayName)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundStyle(DesignTokens.Colors.textSecondary)  // Dimmed text
 


### PR DESCRIPTION
Super simple PR to add help tooltips to app and device names. These are truncated, and it can be hard to know what the app or device name is.