### PR TITLE
feat(ui): add more audio device classifications (icons)

### DIFF
--- a/FineTune/Audio/Extensions/AudioDeviceID+Classification.swift
+++ b/FineTune/Audio/Extensions/AudioDeviceID+Classification.swift
@@ -64,6 +64,16 @@ extension AudioDeviceID {
 
         // Beats
         if name.contains("Beats") { return "beats.headphones" }
+        
+        // Mac variants
+        if name.contains("Mac Studio") { return "macstudio.fill" }
+        if name.contains("Mac mini") { return "macmini.fill" }
+        if name.contains("MacBook") { return "macbook" }
+        if name.contains("iMac") { return "desktopcomputer" }
+        
+        // Display speakers
+        if name.contains("Studio Display") { return "display" }
+        if name.contains("Pro Display XDR") { return "display" }
 
         // Fall back to transport type default
         return transport.defaultIconSymbol
@@ -91,6 +101,10 @@ extension AudioDeviceID {
 
         // MacBook built-in
         if name.contains("MacBook") { return "laptopcomputer" }
+        
+        // Display mic
+        if name.contains("Studio Display") { return "display" }
+        if name.contains("Pro Display XDR") { return "display" }
 
         // Transport-based fallbacks
         switch transport {


### PR DESCRIPTION
This adds a few more audio device classifications to use more appropriate icons for these devices:
```
Mac Studio, Mac mini, MacBook, iMac, Studio Display, Pro Display XDR
```

| Before | After |
|--------|-------|
| ![Screenshot 2026-02-11 at 10 29 52 AM](https://github.com/user-attachments/assets/1174971e-7c56-4b1d-95de-a607988f434c) | ![Screenshot 2026-02-11 at 11 31 45 AM](https://github.com/user-attachments/assets/f0cf9314-5235-459d-a68d-3ebffe911c8d) |

<img width="155" height="155" alt="Screenshot 2026-02-11 at 10 30 57 AM" src="https://github.com/user-attachments/assets/cf400a50-b523-4e48-9d5a-e580fc889bb2" />
<img width="155" height="155" alt="Screenshot 2026-02-11 at 11 46 00 AM" src="https://github.com/user-attachments/assets/31249cf2-6670-4c74-bb86-02739f7a2bca" />
<img width="155" height="155" alt="Screenshot 2026-02-11 at 10 31 11 AM" src="https://github.com/user-attachments/assets/538ea92a-7a43-4778-9785-646650997ee5" />
<img width="155" height="155" alt="Screenshot 2026-02-11 at 11 45 24 AM" src="https://github.com/user-attachments/assets/317f3ff7-e022-4b49-a05c-d4863c7109a9" />
<img width="155" height="155" alt="Screenshot 2026-02-11 at 10 31 34 AM" src="https://github.com/user-attachments/assets/5eecde71-2dc6-49da-b32c-bb678a793db1" />

Definitely looks better too, like for example the Studio Display being the display icon rather than the fallback headphones. (I think the fill versions of the studio/mini icons work better here)

I'm 95% sure that `Mac mini`, `MacBook`, `iMac` and `Pro Display XDR` are correct, but I don't have those to test on to make sure. The spelling of those seems pretty obvious though.`Mac Studio` / `Studio Display` both work obviously. There's probably more devices too that might be missing.