### PR TITLE
Fix percentage width UI glitch by using fixed width instead of minWidth

### DIFF
--- a/FineTune/Views/Components/EditablePercentage.swift
+++ b/FineTune/Views/Components/EditablePercentage.swift
@@ -71,7 +71,7 @@ struct EditablePercentage: View {
                     .fill(Color.primary.opacity(0.08))
             }
         }
-        .frame(minWidth: DesignTokens.Dimensions.percentageWidth, alignment: .trailing)
+        .frame(width: DesignTokens.Dimensions.percentageWidth, alignment: .trailing)
         .contentShape(Rectangle())
         .onTapGesture { if !isEditing { startEditing() } }
         .onHover { hovering in

--- a/FineTune/Views/DesignSystem/DesignTokens.swift
+++ b/FineTune/Views/DesignSystem/DesignTokens.swift
@@ -249,8 +249,8 @@ enum DesignTokens {
             contentWidth - iconSize - Spacing.sm - 100
         }
 
-        /// Percentage text width
-        static let percentageWidth: CGFloat = 32
+        /// Percentage text width (fixed to prevent layout shift)
+        static let percentageWidth: CGFloat = 40
 
         // MARK: VU Meter
 


### PR DESCRIPTION
The percentage display for apps had a UI glitch when transitioning from 2 to 3 characters (e.g., 99% → 100%) because:

- The component used frame(minWidth:) which allows the container to grow
- When text expanded, the container would also expand, causing layout shifts
- The original width of 32pt was also insufficient for the maximum "400%" value

<img width="602" height="338" alt="Screenshot 2026-02-12 at 09 19 09" src="https://github.com/user-attachments/assets/6ed24478-2a60-486e-bcd7-f18256c8a714" />
