### PR TITLE
Fix: Exclude dictation/speech processes from audio tapping

### DIFF
--- a/FineTune/Audio/Monitors/AudioProcessMonitor.swift
+++ b/FineTune/Audio/Monitors/AudioProcessMonitor.swift
@@ -31,6 +31,13 @@ final class AudioProcessMonitor {
         "com.apple.NotificationCenter",
         "com.apple.UserNotifications",
         "com.apple.usernotifications",
+        "com.apple.SpeechRecognitionCore",
+        "com.apple.speech",
+        "com.apple.dictation",
+        "com.apple.corespeech",
+        "com.apple.CoreSpeech",
+        "com.apple.VoiceControl",
+        "com.apple.voicecontrol",
     ]
 
     /// Process names for system daemons (fallback when bundle ID is nil or different format)
@@ -39,6 +46,9 @@ final class AudioProcessMonitor {
         "systemsoundserv",
         "coreaudiod",
         "audiomxd",
+        "speechrecognitiond",
+        "dictationd",
+        "corespeech",
     ]
 
     /// Returns true if the bundle ID or process name indicates a system daemon that should be filtered


### PR DESCRIPTION
**Problem**
When FineTune is running, macOS dictation doesn't behave correctly:
- The dictation chime doesn't play
- Dictation sometimes fails to start entirely
- Quitting FineTune resolves both issues

**Root Cause**
`AudioProcessMonitor` was not filtering dictation-related system daemons (e.g. `CoreSpeech`, `speechrecognitiond`). These processes were being tapped with `muteBehavior = .mutedWhenTapped`, which intercepted their audio output.

**Fix**
Added the following to `systemDaemonPrefixes`:

- `com.apple.SpeechRecognitionCore` — speech-to-text daemon
- `com.apple.speech` — speech framework services
- `com.apple.dictation` — dictation UI/coordination
- `com.apple.corespeech` / `com.apple.CoreSpeech` — CoreSpeech daemon
- `com.apple.VoiceControl` / `com.apple.voicecontrol`

Added the following to `systemDaemonNames`:
- `speechrecognitiond`, `dictationd`, `corespeech`

**Testing**

✅ Dictation chime plays reliably on every activation
✅ Dictation starts and transcribes correctly
✅ Tested with 2+ output devices
✅ Tested device hot-plug during playback
✅ Tested with 5+ apps playing audio simultaneously