### PR TITLE
fix: exclude FaceTime/avconferenced from audio tapping to prevent volume ducking

### DIFF
--- a/FineTune/Audio/Monitors/AudioProcessMonitor.swift
+++ b/FineTune/Audio/Monitors/AudioProcessMonitor.swift
@@ -38,6 +38,8 @@ final class AudioProcessMonitor {
         "com.apple.CoreSpeech",
         "com.apple.VoiceControl",
         "com.apple.voicecontrol",
+        "com.apple.FaceTime",
+        "com.apple.avconference",
     ]
 
     /// Process names for system daemons (fallback when bundle ID is nil or different format)
@@ -49,6 +51,8 @@ final class AudioProcessMonitor {
         "speechrecognitiond",
         "dictationd",
         "corespeech",
+        "FaceTime",
+        "avconferenced",
     ]
 
     /// Returns true if the bundle ID or process name indicates a system daemon that should be filtered


### PR DESCRIPTION
### Problem
When FineTune is running, FaceTime call audio (incoming audio from the other person) is extremely quiet. This "ducking" effect makes calls unusable. Quitting FineTune restores normal levels.

### Root Cause
`AudioProcessMonitor` was detecting `avconferenced` (the real-time audio daemon for FaceTime) and creating a process tap with `muteBehavior = .mutedWhenTapped`. This intercepts the audio stream and breaks macOS's hardware **Acoustic Echo Cancellation (AEC)** loop. The system detects the broken AEC loop and drastically ducks the volume as a fail-safe to prevent feedback.

### Fix
Added FaceTime and `avconferenced` to the system daemon filter lists in [AudioProcessMonitor.swift](cci:7://file:///Users/iftatbhuiyan/FineTune-Feature/FineTune/Audio/Monitors/AudioProcessMonitor.swift:0:0-0:0) so they are ignored by the tapping engine:

- **`systemDaemonPrefixes`:** `com.apple.FaceTime`, `com.apple.avconference`
- **`systemDaemonNames`:** `FaceTime`, `avconferenced`

*Note: This is a workaround that preserves audio quality at the cost of FaceTime not appearing in the FineTune app list.*

### Testing
- [x] FaceTime call audio remains at normal volume with FineTune running.
- [x] Dictation still works correctly (chime plays, activation reliable).
- [x] Other audio apps (Music, browsers, etc.) remain controllable.

Fixes #156  
