### PR TITLE
fix: replace LazyVStack with VStack in GroupedDropdownContentView

### DIFF
--- a/FineTune/Views/Components/DropdownMenu.swift
+++ b/FineTune/Views/Components/DropdownMenu.swift
@@ -299,7 +299,7 @@ private struct GroupedDropdownContentView<Section: Identifiable & Hashable, Item
 
     var body: some View {
         ScrollView(.vertical) {
-            LazyVStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 2) {
                 ForEach(sections) { section in
                     // Section header
                     Text(sectionTitle(section))


### PR DESCRIPTION
#183 

Nested ForEach inside LazyVStack causes SwiftUI's layout engine to recurse infinitely through LazyLayout_Subviews -> ForEachList -> _ViewList_Group -> ForEachList, spiking CPU and freezing the app when changing EQ presets. Switching to VStack avoids the recursion — the preset list is small enough that lazy loading provides no benefit.