### PR TITLE
fix: external headphones now with eq

### DIFF
--- a/FineTune/Audio/Extensions/AudioDeviceID+Classification.swift
+++ b/FineTune/Audio/Extensions/AudioDeviceID+Classification.swift
@@ -57,31 +57,20 @@ extension AudioDeviceID {
     }
 
     /// Checks if the built-in audio device currently has headphones plugged in
-    /// by reading the active data source name.
+    /// by reading the active data source ID.
     func builtInHasHeadphonesActive() -> Bool {
-        // Read the active data source ID
         guard let sourceID: UInt32 = try? read(
             kAudioDevicePropertyDataSource,
             scope: .output,
             defaultValue: 0
         ), sourceID != 0 else {
-            // API failure — safer to not apply headphone correction to speakers
             return false
         }
 
-        // Resolve data source ID to a name string
-        guard let sourceName = readStringWithQualifier(
-            kAudioDevicePropertyDataSourceNameForIDCFString,
-            scope: .output,
-            qualifier: sourceID
-        ) else {
-            return false
-        }
-
-        return sourceName.localizedCaseInsensitiveContains("headphone")
+        // 0x6864706E = 'hdpn' — CoreAudio-internal FourCC for headphones, language-independent
+        return sourceID == 0x6864706E
     }
 }
-
 // MARK: - Device Icon
 
 extension AudioDeviceID {


### PR DESCRIPTION
## Problem

On some Macs, the 3.5mm headphone jack is exposed as a separate built-in
audio device instead of switching the data source of the main built-in device.
This caused FineTune to incorrectly exclude these devices from AutoEQ,
making it impossible to apply parametric EQ to wired headphones on affected
machines. Fixes #179.

## Solution

`builtInHasHeadphonesActive()` now compares the raw CoreAudio data source ID
against `0x6864706E` (`'hdpn'`), the OS-internal FourCC constant for headphones.
This value is hardcoded in CoreAudio and works regardless of system language,
device name, or Mac model.