### PR TITLE
fix: add non-destructive AutoEQ correction toggle

### DIFF
--- a/FineTune/Audio/Engine/AudioEngine.swift
+++ b/FineTune/Audio/Engine/AudioEngine.swift
@@ -780,6 +780,9 @@ final class AudioEngine {
             guard let profile = await autoEQProfileManager.resolveProfile(for: selection.profileID) else { return }
             // Verify tap still exists and is still routed to the same device
             guard tap.currentDeviceUID == deviceUID else { return }
+            guard let latestSelection = settingsManager.getAutoEQSelection(for: deviceUID),
+                  latestSelection.profileID == selection.profileID,
+                  latestSelection.isEnabled else { return }
             tap.updateAutoEQProfile(profile)
         }
     }

--- a/FineTune/Views/Components/AutoEQPicker.swift
+++ b/FineTune/Views/Components/AutoEQPicker.swift
@@ -12,6 +12,8 @@ struct AutoEQPicker: View {
     let onImport: () -> Void
     let onToggleFavorite: (String) -> Void
     let importError: String?
+    var isCorrectionEnabled: Bool = false
+    var onCorrectionToggle: ((Bool) -> Void)?
     var preampEnabled: Bool = true
     var onPreampToggle: (() -> Void)?
 
@@ -27,7 +29,7 @@ struct AutoEQPicker: View {
     private var iconColor: Color {
         if isExpanded {
             return DesignTokens.Colors.accentPrimary
-        } else if profileName != nil {
+        } else if selection != nil || profileName != nil {
             return DesignTokens.Colors.accentPrimary
         } else if isButtonHovered {
             return DesignTokens.Colors.interactiveHover
@@ -95,6 +97,8 @@ struct AutoEQPicker: View {
                 },
                 onToggleFavorite: onToggleFavorite,
                 importErrorMessage: importError,
+                isCorrectionEnabled: isCorrectionEnabled,
+                onCorrectionToggle: onCorrectionToggle,
                 preampEnabled: preampEnabled,
                 onPreampToggle: onPreampToggle
             )

--- a/FineTune/Views/Components/AutoEQSearchPanel.swift
+++ b/FineTune/Views/Components/AutoEQSearchPanel.swift
@@ -12,6 +12,8 @@ struct AutoEQSearchPanel: View {
     let onImport: () -> Void
     let onToggleFavorite: (String) -> Void
     let importErrorMessage: String?
+    var isCorrectionEnabled: Bool = false
+    var onCorrectionToggle: ((Bool) -> Void)?
     var preampEnabled: Bool = true
     var onPreampToggle: (() -> Void)?
 
@@ -34,6 +36,7 @@ struct AutoEQSearchPanel: View {
 
     /// Unified list of all selectable rows for keyboard navigation.
     private enum NavigableItem: Equatable {
+        case correctionToggle
         case noCorrection
         case selectedProfile(String)
         case searchResult(String)
@@ -41,6 +44,8 @@ struct AutoEQSearchPanel: View {
 
         var profileID: String? {
             switch self {
+            case .correctionToggle:
+                return nil
             case .noCorrection: return nil
             case .selectedProfile(let id), .searchResult(let id), .favorite(let id): return id
             }
@@ -48,6 +53,7 @@ struct AutoEQSearchPanel: View {
 
         var itemID: String {
             switch self {
+            case .correctionToggle: return "_correction"
             case .noCorrection: return "_none"
             case .selectedProfile(let id): return "selected_\(id)"
             case .searchResult(let id): return "result_\(id)"
@@ -59,8 +65,12 @@ struct AutoEQSearchPanel: View {
     private var navigableItems: [NavigableItem] {
         var items: [NavigableItem] = [.noCorrection]
 
+        if Self.showsCorrectionToggle(selectedProfileID: selectedProfileID), onCorrectionToggle != nil {
+            items.insert(.correctionToggle, at: 0)
+        }
+
         if let selectedID = selectedProfileID,
-           profileManager.profile(for: selectedID) != nil {
+           Self.showsAssignedProfileRow(selectedProfileName: selectedProfileName(for: selectedID)) {
             items.append(.selectedProfile(selectedID))
         }
 
@@ -105,6 +115,25 @@ struct AutoEQSearchPanel: View {
         return count
     }
 
+    private var correctionEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { isCorrectionEnabled },
+            set: { newValue in onCorrectionToggle?(newValue) }
+        )
+    }
+
+    private func selectedProfileName(for id: String) -> String? {
+        profileManager.profile(for: id)?.name ?? profileManager.catalogEntry(for: id)?.name
+    }
+
+    static func showsCorrectionToggle(selectedProfileID: String?) -> Bool {
+        selectedProfileID != nil
+    }
+
+    static func showsAssignedProfileRow(selectedProfileName: String?) -> Bool {
+        selectedProfileName != nil
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Search field
@@ -136,19 +165,66 @@ struct AutoEQSearchPanel: View {
             Divider()
                 .padding(.horizontal, DesignTokens.Spacing.xs)
 
+            if Self.showsCorrectionToggle(selectedProfileID: selectedProfileID),
+               onCorrectionToggle != nil {
+                Button {
+                    onCorrectionToggle?(!isCorrectionEnabled)
+                } label: {
+                    HStack(spacing: DesignTokens.Spacing.sm) {
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("Correction")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(DesignTokens.Colors.textPrimary)
+
+                            Text(isCorrectionEnabled ? "On" : "Off")
+                                .font(.system(size: 9))
+                                .foregroundStyle(DesignTokens.Colors.textTertiary)
+                        }
+
+                        Spacer()
+
+                        Toggle("Correction", isOn: correctionEnabledBinding)
+                            .toggleStyle(.switch)
+                            .scaleEffect(0.7)
+                            .labelsHidden()
+                            .allowsHitTesting(false)
+                    }
+                    .padding(.horizontal, DesignTokens.Spacing.sm)
+                    .padding(.vertical, DesignTokens.Spacing.xs)
+                    .background(
+                        RoundedRectangle(cornerRadius: 5)
+                            .fill(rowHighlight(for: "_correction", isHovered: hoveredID == "_correction"))
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Correction")
+                .accessibilityValue(isCorrectionEnabled ? "On" : "Off")
+                .accessibilityHint("Toggles the assigned correction profile without removing it")
+                .padding(.horizontal, DesignTokens.Spacing.xs)
+                .whenHovered { isHovered in
+                    hoveredID = isHovered ? "_correction" : nil
+                    if isHovered { highlightedIndex = nil }
+                }
+
+                Divider()
+                    .padding(.horizontal, DesignTokens.Spacing.xs)
+            }
+
             // "None" option to remove correction
             Button {
                 onSelect(nil)
                 onDismiss()
             } label: {
                 HStack(spacing: DesignTokens.Spacing.sm) {
-                    Image(systemName: "xmark.circle")
-                        .font(.system(size: 12))
-                        .foregroundStyle(selectedProfileID == nil ? DesignTokens.Colors.textPrimary : DesignTokens.Colors.textTertiary)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Image(systemName: "xmark.circle")
+                            .font(.system(size: 12))
+                            .foregroundStyle(selectedProfileID == nil ? DesignTokens.Colors.textPrimary : DesignTokens.Colors.textTertiary)
 
-                    Text("No correction")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(selectedProfileID == nil ? DesignTokens.Colors.textPrimary : DesignTokens.Colors.textSecondary)
+                        Text("No correction")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(selectedProfileID == nil ? DesignTokens.Colors.textPrimary : DesignTokens.Colors.textSecondary)
+                    }
 
                     Spacer()
 
@@ -209,6 +285,11 @@ struct AutoEQSearchPanel: View {
                     .whenHovered { hoveredID = $0 ? "_preamp" : nil }
                     .padding(.horizontal, DesignTokens.Spacing.xs)
                 }
+            } else if let selectedID = selectedProfileID,
+                      let selectedName = selectedProfileName(for: selectedID),
+                      Self.showsAssignedProfileRow(selectedProfileName: selectedName) {
+                selectedCatalogProfileRow(id: selectedID, name: selectedName)
+                    .padding(.horizontal, DesignTokens.Spacing.xs)
             }
 
             // Results / Favorites / Empty state
@@ -589,7 +670,13 @@ struct AutoEQSearchPanel: View {
         guard let index = highlightedIndex, index < items.count else { return }
 
         let item = items[index]
-        if let profileID = item.profileID {
+        switch item {
+        case .correctionToggle:
+            onCorrectionToggle?(!isCorrectionEnabled)
+        case .noCorrection:
+            onSelect(nil)
+            onDismiss()
+        case .selectedProfile(let profileID), .searchResult(let profileID), .favorite(let profileID):
             // Check if already loaded
             if let profile = profileManager.profile(for: profileID) {
                 onSelect(profile)
@@ -597,9 +684,6 @@ struct AutoEQSearchPanel: View {
             } else if let entry = profileManager.catalogEntries.first(where: { $0.id == profileID }) {
                 selectCatalogEntry(entry)
             }
-        } else {
-            onSelect(nil)
-            onDismiss()
         }
     }
 
@@ -634,5 +718,54 @@ struct AutoEQSearchPanel: View {
         } else {
             return DesignTokens.Colors.interactiveDefault
         }
+    }
+
+    @ViewBuilder
+    private func selectedCatalogProfileRow(id: String, name: String) -> some View {
+        let itemID = "selected_\(id)"
+        let isRowHovered = hoveredID == id
+
+        Button {
+            if let profile = profileManager.profile(for: id) {
+                onSelect(profile)
+                onDismiss()
+            } else if let entry = profileManager.catalogEntry(for: id) {
+                selectCatalogEntry(entry)
+            }
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(name)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(DesignTokens.Colors.textPrimary)
+                        .lineLimit(1)
+
+                    Text("Selected profile")
+                        .font(.system(size: 9))
+                        .foregroundStyle(DesignTokens.Colors.textTertiary)
+                }
+
+                Spacer()
+
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(Color.accentColor)
+            }
+            .padding(.horizontal, DesignTokens.Spacing.sm)
+            .frame(height: itemHeight)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(rowHighlight(for: itemID, isHovered: isRowHovered))
+            )
+        }
+        .buttonStyle(.plain)
+        .whenHovered { isHovered in
+            hoveredID = isHovered ? id : nil
+            if isHovered { highlightedIndex = nil }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(name)
+        .accessibilityAddTraits(.isSelected)
+        .accessibilityHint("Assigned correction profile")
     }
 }

--- a/FineTune/Views/MenuBarPopupView.swift
+++ b/FineTune/Views/MenuBarPopupView.swift
@@ -521,6 +521,7 @@ struct MenuBarPopupView: View {
                     let profileName: String? = {
                         guard let sel = selection else { return nil }
                         return audioEngine.autoEQProfileManager.profile(for: sel.profileID)?.name
+                            ?? audioEngine.autoEQProfileManager.catalogEntry(for: sel.profileID)?.name
                     }()
 
                     DeviceRow(
@@ -541,8 +542,8 @@ struct MenuBarPopupView: View {
                         },
                         autoEQProfileName: profileName,
                         autoEQEnabled: selection?.isEnabled ?? false,
-                        onAutoEQToggle: {
-                            audioEngine.setAutoEQEnabled(for: device.uid, enabled: !(selection?.isEnabled ?? false))
+                        onAutoEQToggle: { enabled in
+                            audioEngine.setAutoEQEnabled(for: device.uid, enabled: enabled)
                         },
                         autoEQProfileManager: audioEngine.autoEQProfileManager,
                         autoEQSelection: selection,

--- a/FineTune/Views/Rows/DeviceRow.swift
+++ b/FineTune/Views/Rows/DeviceRow.swift
@@ -16,7 +16,7 @@ struct DeviceRow: View {
     // AutoEQ (all optional — existing call sites work without them)
     let autoEQProfileName: String?
     let autoEQEnabled: Bool
-    let onAutoEQToggle: (() -> Void)?
+    let onAutoEQToggle: ((Bool) -> Void)?
     let autoEQProfileManager: AutoEQProfileManager?
     let autoEQSelection: AutoEQSelection?
     let autoEQFavoriteIDs: Set<String>
@@ -47,7 +47,7 @@ struct DeviceRow: View {
         onMuteToggle: @escaping () -> Void,
         autoEQProfileName: String? = nil,
         autoEQEnabled: Bool = false,
-        onAutoEQToggle: (() -> Void)? = nil,
+        onAutoEQToggle: ((Bool) -> Void)? = nil,
         autoEQProfileManager: AutoEQProfileManager? = nil,
         autoEQSelection: AutoEQSelection? = nil,
         autoEQFavoriteIDs: Set<String> = [],
@@ -115,8 +115,8 @@ struct DeviceRow: View {
                         .lineLimit(1)
                         .help(device.name)
 
-                    if let profileName = autoEQProfileName, autoEQEnabled {
-                        Text(profileName)
+                    if let subtitle = Self.autoEQSubtitle(profileName: autoEQProfileName, isEnabled: autoEQEnabled) {
+                        Text(subtitle)
                             .font(.system(size: 9))
                             .foregroundStyle(DesignTokens.Colors.textTertiary)
                             .lineLimit(1)
@@ -139,6 +139,8 @@ struct DeviceRow: View {
                         onImport: onImport,
                         onToggleFavorite: { id in onAutoEQToggleFavorite?(id) },
                         importError: autoEQImportError,
+                        isCorrectionEnabled: autoEQEnabled,
+                        onCorrectionToggle: onAutoEQToggle,
                         preampEnabled: autoEQPreampEnabled,
                         onPreampToggle: onAutoEQPreampToggle
                     )
@@ -195,6 +197,13 @@ struct DeviceRow: View {
             guard !isEditing else { return }
             sliderValue = Double(newValue)
         }
+    }
+}
+
+extension DeviceRow {
+    static func autoEQSubtitle(profileName: String?, isEnabled: Bool) -> String? {
+        guard let profileName else { return nil }
+        return isEnabled ? profileName : "\(profileName) (off)"
     }
 }
 

--- a/guide/autoeq.md
+++ b/guide/autoeq.md
@@ -25,6 +25,7 @@ If you have a custom measurement or want to use a profile from another source:
 1. Click **"Import ParametricEQ.txt..."** at the bottom of the AutoEQ panel
 2. Select your `.txt` file
 3. The profile is imported and applied to the selected device
+4. Use the **Correction** switch in the picker to A/B the profile without removing it
 
 FineTune accepts [EqualizerAPO](https://sourceforge.net/projects/equalizerapo/) ParametricEQ.txt files:
 
@@ -55,5 +56,6 @@ Up to 10 filters per profile. The `Preamp` line sets a global gain offset to pre
 ## Managing Profiles
 
 - Each device remembers its assigned profile independently
-- To remove a profile, click the wand icon and select **No correction**
+- To temporarily bypass a profile, click the wand icon and turn **Correction** off
+- To remove a profile entirely, click the wand icon and select **No correction**
 - Favorite frequently-used profiles for quick access with the star icon — favorited profiles appear at the top of search results and are shown when the search field is empty


### PR DESCRIPTION
## Summary

- add a `Correction` on/off control for devices that already have an AutoEQ or imported `ParametricEQ.txt` profile assigned
- preserve the assigned profile when correction is off so users can do fast A/B comparisons instead of reselecting the profile each time
- keep disabled assignments visible in the device row and document the difference between bypassing correction and clearing it entirely

Closes #207.

## Why

This change is about listening workflow, not new DSP behavior. FineTune already stores assigned AutoEQ state as `profileID + isEnabled`, and the engine already bypasses correction when `isEnabled` is false. The missing piece was the UI.

For EQ work, fast bypass is important because hearing adapts quickly. Users need to compare corrected vs. raw sound within a short window, and `No correction` was too destructive for that because it removed the assignment instead of simply turning it off.

## What changed

- surface a `Correction` control in the picker when a profile is already assigned
- wire that control to the existing enable/disable path instead of clearing the profile
- keep assigned profiles visible in the picker and device row even when correction is off
- guard the async profile-resolution path so a late resolve cannot re-enable correction after the user has switched it off
- make the new picker rows behave correctly for pointer and accessibility users
- update `guide/autoeq.md` to explain bypass vs. removal

## Verification

- `xcodebuild test -project "FineTune.xcodeproj" -scheme "FineTune" -destination "platform=macOS" -only-testing:FineTuneTests/AutoEQPresentationTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" DEVELOPMENT_TEAM=""`
- `xcodebuild build -project "FineTune.xcodeproj" -scheme "FineTune" -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" DEVELOPMENT_TEAM=""`