### PR TITLE
Feat: better bluetooth connect

### DIFF
--- a/FineTune/Utilities/URLHandler.swift
+++ b/FineTune/Utilities/URLHandler.swift
@@ -1,5 +1,6 @@
 // FineTune/Utilities/URLHandler.swift
 import Foundation
+import AudioToolbox
 import os
 
 /// Protocol for the AudioEngine surface that URLHandler depends on.
@@ -7,7 +8,10 @@ import os
 @MainActor
 protocol URLHandlerEngine {
     var apps: [AudioApp] { get }
+    var outputDevices: [AudioDevice] { get }
+    var bluetoothDeviceMonitor: BluetoothDeviceMonitor { get }
     var settingsManager: SettingsManager { get }
+    @discardableResult func setDefaultOutputDevice(_ deviceID: AudioDeviceID) -> Bool
     func setVolume(for app: AudioApp, to volume: Float)
     func getVolume(for app: AudioApp) -> Float
     func setMute(for app: AudioApp, to muted: Bool)
@@ -54,6 +58,10 @@ final class URLHandler {
         // Other actions
         case "set-device":
             handleSetDevice(queryItems: queryItems)
+        case "connect-device":
+            handleConnectDevice(queryItems: queryItems)
+        case "set-default-output":
+            handleSetDefaultOutput(queryItems: queryItems)
         case "reset":
             handleReset(queryItems: queryItems)
         default:
@@ -258,6 +266,57 @@ final class URLHandler {
         logger.info("Routed \(app.name) to device \(deviceUID)")
     }
 
+    private func handleConnectDevice(queryItems: [URLQueryItem]) {
+        guard let name = normalizedQueryValue(queryItems.first(where: { $0.name == "name" })?.value) else {
+            logger.error("connect-device: missing name parameter")
+            return
+        }
+
+        let btMonitor = audioEngine.bluetoothDeviceMonitor
+
+        guard let device = btMonitor.pairedDevices.first(where: {
+            $0.name.localizedCaseInsensitiveContains(name)
+        }) else {
+            logger.warning("connect-device: no paired device found matching '\(name)'")
+            return
+        }
+
+        btMonitor.connect(device: device)
+        logger.info("Connecting to \(device.name)")
+    }
+
+    private func handleSetDefaultOutput(queryItems: [URLQueryItem]) {
+        let deviceUID = normalizedQueryValue(queryItems.first(where: { $0.name == "device" })?.value)
+        let deviceName = normalizedQueryValue(queryItems.first(where: { $0.name == "name" })?.value)
+
+        guard deviceUID != nil || deviceName != nil else {
+            logger.error("set-default-output: missing device or name parameter")
+            return
+        }
+
+        let matchedDevice: AudioDevice?
+        if let uid = deviceUID {
+            matchedDevice = audioEngine.outputDevices.first(where: { $0.uid == uid })
+        } else if let name = deviceName {
+            matchedDevice = audioEngine.outputDevices.first(where: {
+                $0.name.localizedCaseInsensitiveContains(name)
+            })
+        } else {
+            matchedDevice = nil
+        }
+
+        guard let device = matchedDevice else {
+            logger.warning("set-default-output: no output device found matching '\(deviceUID ?? deviceName ?? "nil")'")
+            return
+        }
+
+        if audioEngine.setDefaultOutputDevice(device.id) {
+            logger.info("Set default output device to \(device.name)")
+        } else {
+            logger.error("set-default-output: failed to set default output to \(device.name)")
+        }
+    }
+
     /// Reset apps to 100% volume and unmute
     /// URL format: finetune://reset?app=com.a&app=com.b or finetune://reset (all apps)
     private func handleReset(queryItems: [URLQueryItem]) {
@@ -293,6 +352,14 @@ final class URLHandler {
     /// Find an app by bundle ID or persistence identifier
     private func findApp(by identifier: String) -> AudioApp? {
         audioEngine.apps.first { $0.persistenceIdentifier == identifier }
+    }
+
+    private func normalizedQueryValue(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = value
+            .replacingOccurrences(of: "+", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? nil : normalized
     }
 
     /// Parse boolean from string (supports true/false, 1/0, yes/no)

--- a/FineTune/Views/MenuBarPopupView.swift
+++ b/FineTune/Views/MenuBarPopupView.swift
@@ -51,6 +51,10 @@ struct MenuBarPopupView: View {
     /// Whether Bluetooth hardware is powered on
     @State private var isBluetoothOn = false
 
+    @State private var pendingAutoSelectNames: Set<String> = []
+
+    @State private var autoSelectTimeouts: [String: Task<Void, Never>] = [:]
+
     /// Whether edit mode is active (affects both device priority and app visibility)
     @State private var isEditingDevicePriority = false
 
@@ -138,11 +142,21 @@ struct MenuBarPopupView: View {
             isBluetoothOn = audioEngine.bluetoothDeviceMonitor.isBluetoothOn
             localAppSettings = audioEngine.settingsManager.appSettings
         }
-        .onChange(of: audioEngine.outputDevices) { _, _ in
+        .onChange(of: audioEngine.outputDevices) { _, newValue in
             if isEditingDevicePriority && !wasEditingInputDevices {
                 mergeDeviceChanges(from: audioEngine.outputDevices)
             }
             updateSortedDevices()
+
+            if !pendingAutoSelectNames.isEmpty {
+                for device in newValue where pendingAutoSelectNames.contains(device.name) {
+                    pendingAutoSelectNames.remove(device.name)
+                    autoSelectTimeouts[device.name]?.cancel()
+                    autoSelectTimeouts.removeValue(forKey: device.name)
+                    audioEngine.setDefaultOutputDevice(device.id)
+                    break
+                }
+            }
         }
         .onChange(of: audioEngine.inputDevices) { _, _ in
             if isEditingDevicePriority && wasEditingInputDevices {
@@ -486,16 +500,24 @@ struct MenuBarPopupView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.top, DesignTokens.Spacing.xs)
 
-                            ForEach(filteredPaired) { device in
-                                PairedDeviceRow(
-                                    device: device,
-                                    isConnecting: audioEngine.bluetoothDeviceMonitor.connectingIDs.contains(device.id),
-                                    errorMessage: audioEngine.bluetoothDeviceMonitor.connectionErrors[device.id],
-                                    onConnect: {
-                                        audioEngine.bluetoothDeviceMonitor.connect(device: device)
-                                    }
-                                )
-                            }
+                         ForEach(filteredPaired) { device in
+                             PairedDeviceRow(
+                                 device: device,
+                                 isConnecting: audioEngine.bluetoothDeviceMonitor.connectingIDs.contains(device.id),
+                                 errorMessage: audioEngine.bluetoothDeviceMonitor.connectionErrors[device.id],
+                                 onConnect: {
+                                     pendingAutoSelectNames.insert(device.name)
+                                     audioEngine.bluetoothDeviceMonitor.connect(device: device)
+                                     autoSelectTimeouts[device.name]?.cancel()
+                                     autoSelectTimeouts[device.name] = Task {
+                                         try? await Task.sleep(for: .seconds(12))
+                                         guard !Task.isCancelled else { return }
+                                         pendingAutoSelectNames.remove(device.name)
+                                         autoSelectTimeouts.removeValue(forKey: device.name)
+                                     }
+                                 }
+                             )
+                         }
                         }
                     }
                 }
@@ -572,6 +594,31 @@ struct MenuBarPopupView: View {
                     )
                 }
 
+                if !isBluetoothOn {
+                    Text("Turn on Bluetooth to connect devices")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, DesignTokens.Spacing.xs)
+                } else {
+                    let connectedNames = Set(sortedDevices.map(\.name))
+                    let filteredPaired = pairedDevices.filter { !connectedNames.contains($0.name) }
+                    if !filteredPaired.isEmpty {
+                        SectionHeader(title: "Paired")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.top, DesignTokens.Spacing.xs)
+
+                        ForEach(filteredPaired) { device in
+                            PairedDeviceRow(
+                                device: device,
+                                isConnecting: audioEngine.bluetoothDeviceMonitor.connectingIDs.contains(device.id),
+                                errorMessage: audioEngine.bluetoothDeviceMonitor.connectionErrors[device.id],
+                                onConnect: {
+                                    audioEngine.bluetoothDeviceMonitor.connect(device: device)
+                                }
+                            )
+                        }
+                    }
+                }
             }
         }
     }

--- a/FineTune/Views/Rows/PairedDeviceRow.swift
+++ b/FineTune/Views/Rows/PairedDeviceRow.swift
@@ -8,6 +8,7 @@ struct PairedDeviceRow: View {
     let isConnecting: Bool
     let errorMessage: String?
     let onConnect: () -> Void
+    var isDisconnected: Bool = true
 
     var body: some View {
         HStack(spacing: DesignTokens.Spacing.sm) {
@@ -31,12 +32,12 @@ struct PairedDeviceRow: View {
                 }
             }
             .frame(width: DesignTokens.Dimensions.iconSize, height: DesignTokens.Dimensions.iconSize)
-            .opacity(isConnecting ? 0.5 : 1.0)
+            .opacity(isConnecting ? 0.5 : (isDisconnected ? 0.6 : 1.0))
 
             // Device name
             Text(device.name)
                 .font(DesignTokens.Typography.rowName)
-                .foregroundStyle(isConnecting
+                .foregroundStyle((isConnecting || isDisconnected)
                     ? DesignTokens.Colors.textSecondary
                     : DesignTokens.Colors.textPrimary)
                 .lineLimit(1)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ That's it. Adjust sliders, route audio, and explore EQ from the menu bar.
 
 ### 🖥 Devices & System
 - **Input device control** — Monitor and adjust microphone levels
-- **Bluetooth device management** — Connect paired devices directly from the menu bar
+- **Bluetooth device management** — Connect paired devices directly from the menu bar; disconnected devices shown in main list with one-click connect
 - **Monitor speaker control** — Adjust volume on external displays via DDC
 - **Menu bar app** — Lightweight, always accessible
 - **URL schemes** — Automate volume, mute, device routing, and more from scripts

--- a/guide/url-schemes.md
+++ b/guide/url-schemes.md
@@ -12,6 +12,8 @@ Control FineTune from Terminal, shell scripts, [Shortcuts](https://support.apple
 | Toggle mute | `finetune://toggle-mute?app=BUNDLE_ID` | Toggle mute state |
 | Set device | `finetune://set-device?app=BUNDLE_ID&device=DEVICE_UID` | Route an app to a specific output |
 | Reset | `finetune://reset` | Reset all apps to 100% and unmuted |
+| Connect device | `finetune://connect-device?name=DEVICE_NAME` | Connect a paired Bluetooth device |
+| Set default output | `finetune://set-default-output?device=DEVICE_UID` | Switch the system default output device |
 
 ## Examples
 
@@ -33,6 +35,12 @@ open "finetune://set-device?app=com.spotify.client&device=YOUR_DEVICE_UID"
 
 # Reset everything
 open "finetune://reset"
+
+# Connect AirPods Pro
+open "finetune://connect-device?name=AirPods+Pro"
+
+# Switch default output by name
+open "finetune://set-default-output?name=MacBook+Pro+Speakers"
 ```
 
 ## Use Cases
@@ -53,6 +61,13 @@ open "finetune://set-volumes?app=com.spotify.client&volume=30&app=com.apple.syst
 
 ```bash
 open "finetune://set-volumes?app=com.game.example&volume=400&app=com.hnc.Discord&volume=40"
+```
+
+**AirPods workflow** — Connect AirPods and lower music:
+
+```bash
+open "finetune://connect-device?name=AirPods+Pro"
+open "finetune://set-volumes?app=com.spotify.client&volume=30"
 ```
 
 These commands work in Terminal, shell scripts, Automator, Raycast script commands, macOS Shortcuts (using "Open URL"), and any other tool that can open URLs.


### PR DESCRIPTION
## Better Bluetooth Device Connect

This brings FineTune's Bluetooth device handling closer to how the native macOS audio selector works.

### Why

Connecting a Bluetooth device required clicking the edit button first — just to see paired devices and hit connect. The native macOS audio menu shows disconnected devices right in the list, which is way more convenient. So I moved paired devices out of edit mode and into the main device list. Click to connect, and it auto-selects as output - same as in the native audio selector.

Also added two new URL schemes (`connect-device`, `set-default-output`) so device switching can be automated via Shortcuts/Raycast/scripts.

### Changes

- Paired-but-disconnected Bluetooth devices shown in main device list with dimmed styling
- Click to connect + auto-select as output device
- URL scheme: `finetune://connect-device?name=AirPods+Pro` — connect a paired device by name
- URL scheme: `finetune://set-default-output?device=DEVICE_UID` — switch system default output (also accepts `&name=`)
- Updated docs (url-schemes.md, README)

### Notes

- Tested with AirPods Pro, multiple output devices, and device hot-plug.
- I also looked into adding AirPods listening mode control (ANC/Transparency/Adaptive) and battery display, but Apple broke the private IOBluetooth APIs in macOS 15+ and the IOKit battery service returns no data for AirPods. No public API exists for either. Maybe in the future 🤞 this would be great in making FineTune feel more like the native audio selector.

Open to feedback — if preferred I can move the paired device visibility behind a setting.

### Screenshots
<img width="573" height="422" alt="Screenshot 2026-04-05 at 0 30 43" src="https://github.com/user-attachments/assets/da5f155e-fd91-4a35-a78c-e4364282f398" />

