### PR TITLE
feat(audio): add loudness compensation and equalization based on ISO 226 contours

### DIFF
--- a/FineTune/Audio/EQ/BiquadMath.swift
+++ b/FineTune/Audio/EQ/BiquadMath.swift
@@ -89,6 +89,28 @@ enum BiquadMath {
         return [b0 / a0, b1 / a0, b2 / a0, a1 / a0, a2 / a0]
     }
 
+    /// Compute high-pass biquad coefficients (RBJ cookbook, 2nd-order Butterworth)
+    /// Returns [b0, b1, b2, a1, a2] normalized by a0 for vDSP_biquad
+    static func highPassCoefficients(
+        frequency: Double,
+        q: Double,
+        sampleRate: Double
+    ) -> [Double] {
+        let omega = 2.0 * .pi * frequency / sampleRate
+        let sinW = sin(omega)
+        let cosW = cos(omega)
+        let alpha = sinW / (2.0 * q)
+
+        let b0 =  (1.0 + cosW) / 2.0
+        let b1 = -(1.0 + cosW)
+        let b2 =  (1.0 + cosW) / 2.0
+        let a0 =  1.0 + alpha
+        let a1 = -2.0 * cosW
+        let a2 =  1.0 - alpha
+
+        return [b0 / a0, b1 / a0, b2 / a0, a1 / a0, a2 / a0]
+    }
+
     /// Correct a filter frequency optimized at `sourceRate` for use at `targetRate`.
     /// Uses inverse bilinear transform (digital→analog) then forward (analog→digital).
     static func preWarpFrequency(

--- a/FineTune/Audio/Engine/AudioEngine.swift
+++ b/FineTune/Audio/Engine/AudioEngine.swift
@@ -328,6 +328,7 @@ final class AudioEngine {
         deviceVolumeMonitor.onVolumeChanged = { [weak self] deviceID, newVolume in
             guard let self else { return }
             guard let deviceUID = self.deviceMonitor.outputDevices.first(where: { $0.id == deviceID })?.uid else { return }
+            let loudnessSettings = self.settingsManager.appSettings
             for (_, tap) in self.taps {
                 if tap.currentDeviceUID == deviceUID {
                     tap.currentDeviceVolume = newVolume
@@ -335,6 +336,11 @@ final class AudioEngine {
                        self.outputVolumeBackend(for: deviceID) == .software {
                         tap.volume = self.effectiveVolume(for: tap.app.id, deviceUIDs: tap.currentDeviceUIDs)
                     }
+                    tap.updateLoudnessCompensation(
+                        volume: newVolume,
+                        amount: loudnessSettings.loudnessCompensationAmount,
+                        enabled: loudnessSettings.loudnessCompensationEnabled
+                    )
                 }
             }
         }
@@ -653,6 +659,7 @@ final class AudioEngine {
             applyTapOutputState(to: tap, for: tap.app.id, deviceUIDs: tap.currentDeviceUIDs)
             tap.updateEQSettings(.flat)
             tap.updateAutoEQProfile(nil)
+            tap.updateLoudnessCompensation(volume: tap.currentDeviceVolume, amount: 1.0, enabled: false)
         }
 
         // 6. Re-apply from clean settings (re-establishes routing to system default)
@@ -788,6 +795,28 @@ final class AudioEngine {
         settingsManager.autoEQPreampEnabled = enabled
         for tap in taps.values {
             tap.setAutoEQPreampEnabled(enabled)
+        }
+    }
+
+    func setLoudnessCompensationEnabled(_ enabled: Bool) {
+        let amount = settingsManager.appSettings.loudnessCompensationAmount
+        for tap in taps.values {
+            tap.updateLoudnessCompensation(volume: tap.currentDeviceVolume, amount: amount, enabled: enabled)
+        }
+    }
+
+    func setLoudnessCompensationAmount(_ amount: Float) {
+        let enabled = settingsManager.appSettings.loudnessCompensationEnabled
+        for tap in taps.values {
+            tap.updateLoudnessCompensation(volume: tap.currentDeviceVolume, amount: amount, enabled: enabled)
+        }
+    }
+
+    func setLoudnessEqualizationEnabled(_ enabled: Bool) {
+        var settings = LoudnessEqualizerSettings()
+        settings.enabled = enabled
+        for tap in taps.values {
+            tap.updateLoudnessEqualization(settings)
         }
     }
 
@@ -1031,6 +1060,14 @@ final class AudioEngine {
             tap.updateEQSettings(eqSettings)
             tap.setAutoEQPreampEnabled(settingsManager.autoEQPreampEnabled)
             applyAutoEQToTap(tap)
+            var loudnessEqSettings = LoudnessEqualizerSettings()
+            loudnessEqSettings.enabled = settingsManager.appSettings.loudnessEqualizationEnabled
+            tap.updateLoudnessEqualization(loudnessEqSettings)
+            tap.updateLoudnessCompensation(
+                volume: tap.currentDeviceVolume,
+                amount: settingsManager.appSettings.loudnessCompensationAmount,
+                enabled: settingsManager.appSettings.loudnessCompensationEnabled
+            )
 
             logger.debug("Created tap for \(app.name) on \(deviceUIDs.count) device(s)")
         } catch {
@@ -1171,6 +1208,14 @@ final class AudioEngine {
             tap.updateEQSettings(eqSettings)
             tap.setAutoEQPreampEnabled(settingsManager.autoEQPreampEnabled)
             applyAutoEQToTap(tap)
+            var loudnessEqSettings = LoudnessEqualizerSettings()
+            loudnessEqSettings.enabled = settingsManager.appSettings.loudnessEqualizationEnabled
+            tap.updateLoudnessEqualization(loudnessEqSettings)
+            tap.updateLoudnessCompensation(
+                volume: tap.currentDeviceVolume,
+                amount: settingsManager.appSettings.loudnessCompensationAmount,
+                enabled: settingsManager.appSettings.loudnessCompensationEnabled
+            )
 
             logger.debug("Created tap for \(app.name)")
         } catch {

--- a/FineTune/Audio/Engine/ProcessTapController.swift
+++ b/FineTune/Audio/Engine/ProcessTapController.swift
@@ -105,11 +105,15 @@ final class ProcessTapController: ProcessTapControlling {
     private nonisolated(unsafe) var secondaryRampCoefficient: Float = 0.0007
     private nonisolated(unsafe) var eqProcessor: EQProcessor?
     private nonisolated(unsafe) var autoEQProcessor: AutoEQProcessor?
+    private nonisolated(unsafe) var loudnessCompensator: LoudnessCompensator?
+    private nonisolated(unsafe) var loudnessEqualizerProcessor: LoudnessEqualizer?
     /// Independent EQ processors for secondary tap during crossfade.
     /// Each tap needs its own biquad delay buffers — sharing would corrupt filter state
     /// because both callbacks write concurrently from different HAL I/O threads.
     private nonisolated(unsafe) var secondaryEQProcessor: EQProcessor?
     private nonisolated(unsafe) var secondaryAutoEQProcessor: AutoEQProcessor?
+    private nonisolated(unsafe) var secondaryLoudnessCompensator: LoudnessCompensator?
+    private nonisolated(unsafe) var secondaryLoudnessEqualizerProcessor: LoudnessEqualizer?
 
     // Target device UIDs for synchronized multi-output (first is clock source)
     private var targetDeviceUIDs: [String]
@@ -229,6 +233,21 @@ final class ProcessTapController: ProcessTapControlling {
     func setAutoEQPreampEnabled(_ enabled: Bool) {
         autoEQProcessor?.setPreampEnabled(enabled)
         secondaryAutoEQProcessor?.setPreampEnabled(enabled)
+    }
+
+    func updateLoudnessCompensation(volume: Float, amount: Float, enabled: Bool) {
+        if enabled {
+            loudnessCompensator?.updateForVolume(volume, amount: amount)
+            secondaryLoudnessCompensator?.updateForVolume(volume, amount: amount)
+        } else {
+            loudnessCompensator?.setEnabled(false)
+            secondaryLoudnessCompensator?.setEnabled(false)
+        }
+    }
+
+    func updateLoudnessEqualization(_ settings: LoudnessEqualizerSettings) {
+        loudnessEqualizerProcessor?.updateSettings(settings)
+        secondaryLoudnessEqualizerProcessor?.updateSettings(settings)
     }
 
     // MARK: - Multi-Device Aggregate Configuration
@@ -419,6 +438,8 @@ final class ProcessTapController: ProcessTapControlling {
 
         eqProcessor = EQProcessor(sampleRate: sampleRate)
         autoEQProcessor = AutoEQProcessor(sampleRate: sampleRate)
+        loudnessEqualizerProcessor = LoudnessEqualizer(settings: LoudnessEqualizerSettings(), sampleRate: Float(sampleRate), channelCount: 2)
+        loudnessCompensator = LoudnessCompensator(sampleRate: sampleRate)
 
         // Create IO proc with gain processing
         nextCallbackID += 1
@@ -615,6 +636,7 @@ final class ProcessTapController: ProcessTapControlling {
     private func endInvalidation() {
         secondaryEQProcessor = nil
         secondaryAutoEQProcessor = nil
+        secondaryLoudnessCompensator = nil
         _invalidating = false
     }
 
@@ -777,6 +799,14 @@ final class ProcessTapController: ProcessTapControlling {
         }
         secondaryAutoEQProcessor = secAutoEQ
 
+        let secLoudnessEqualizer = LoudnessEqualizer(settings: loudnessEqualizerProcessor?.currentSettings ?? LoudnessEqualizerSettings(), sampleRate: Float(sampleRate), channelCount: 2)
+        secondaryLoudnessEqualizerProcessor = secLoudnessEqualizer
+
+        let secLoudness = LoudnessCompensator(sampleRate: sampleRate)
+        secLoudness.updateForVolume(_currentDeviceVolume)
+        if loudnessCompensator?.isEnabled == false { secLoudness.setEnabled(false) }
+        secondaryLoudnessCompensator = secLoudness
+
         nextCallbackID += 1
         _secondaryCallbackID = nextCallbackID
         let secondaryCallbackID = nextCallbackID
@@ -816,6 +846,8 @@ final class ProcessTapController: ProcessTapControlling {
         secondaryResources.destroy()
         secondaryEQProcessor = nil
         secondaryAutoEQProcessor = nil
+        secondaryLoudnessCompensator = nil
+        secondaryLoudnessEqualizerProcessor = nil
     }
 
     private func promoteSecondaryToPrimary() {
@@ -832,18 +864,26 @@ final class ProcessTapController: ProcessTapControlling {
         // so defer their deallocation to ensure no use-after-free on the RT thread.
         let oldEQ = eqProcessor
         let oldAutoEQ = autoEQProcessor
+        let oldLoudness = loudnessCompensator
+        let oldLoudnessEqualizer = loudnessEqualizerProcessor
         eqProcessor = secondaryEQProcessor
         autoEQProcessor = secondaryAutoEQProcessor
+        loudnessCompensator = secondaryLoudnessCompensator
+        loudnessEqualizerProcessor = secondaryLoudnessEqualizerProcessor
         secondaryEQProcessor = nil
         secondaryAutoEQProcessor = nil
+        secondaryLoudnessCompensator = nil
+        secondaryLoudnessEqualizerProcessor = nil
 
         // Deferred cleanup: hold old processors alive briefly so any in-flight RT callback
         // that read the pointer before the swap finishes its buffer without accessing freed memory.
         // 0.5s is conservative — audio callbacks run at ~5ms intervals.
-        if oldEQ != nil || oldAutoEQ != nil {
+        if oldEQ != nil || oldAutoEQ != nil || oldLoudness != nil || oldLoudnessEqualizer != nil {
             DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
                 _ = oldEQ
                 _ = oldAutoEQ
+                _ = oldLoudness
+                _ = oldLoudnessEqualizer
             }
         }
 
@@ -975,6 +1015,8 @@ final class ProcessTapController: ProcessTapControlling {
             rampCoefficient = 1 - exp(-1 / (Float(deviceSampleRate) * 0.030))
             eqProcessor?.updateSampleRate(deviceSampleRate)
             autoEQProcessor?.updateSampleRate(deviceSampleRate)
+            loudnessEqualizerProcessor?.updateSampleRate(Float(deviceSampleRate))
+            loudnessCompensator?.updateSampleRate(deviceSampleRate)
         }
     }
 
@@ -993,7 +1035,9 @@ final class ProcessTapController: ProcessTapControlling {
         preferredStereoRight: Int,
         currentVol: inout Float,
         eqProc: EQProcessor?,
-        autoEQProc: AutoEQProcessor?
+        autoEQProc: AutoEQProcessor?,
+        loudnessEqualizerProc: LoudnessEqualizer?,
+        loudnessCompensatorProc: LoudnessCompensator?
     ) {
         let inputBufferCount = inputBuffers.count
         let outputBufferCount = outputBuffers.count
@@ -1121,6 +1165,16 @@ final class ProcessTapController: ProcessTapControlling {
                 autoEQProc.process(input: outputSamples, output: outputSamples, frameCount: frameCount)
             }
 
+            // Loudness Equalization (before loudness compensation)
+            if let loudnessEqualizerProc, loudnessEqualizerProc.isEnabled, eqCanProcessStereoInterleaved {
+                loudnessEqualizerProc.process(input: UnsafePointer(outputSamples), output: outputSamples, frameCount: frameCount, channelCount: outputChannels)
+            }
+
+            // Loudness compensation (after all EQ, before limiting)
+            if let loudnessCompensatorProc, loudnessCompensatorProc.isEnabled, eqCanProcessStereoInterleaved {
+                loudnessCompensatorProc.process(input: outputSamples, output: outputSamples, frameCount: frameCount)
+            }
+
             let writtenSampleCount = frameCount * outputChannels
             SoftLimiter.processBuffer(outputSamples, sampleCount: writtenSampleCount)
         }
@@ -1220,6 +1274,8 @@ final class ProcessTapController: ProcessTapControlling {
         let stereoRight: Int
         let eqProc: EQProcessor?
         let autoEQProc: AutoEQProcessor?
+        let loudnessEqualizerProc: LoudnessEqualizer?
+        let loudnessCompensatorProc: LoudnessCompensator?
 
         if isPrimary {
             currentVol = _primaryCurrentVolume
@@ -1232,6 +1288,8 @@ final class ProcessTapController: ProcessTapControlling {
             stereoRight = _primaryPreferredStereoRightChannel
             eqProc = eqProcessor
             autoEQProc = autoEQProcessor
+            loudnessEqualizerProc = loudnessEqualizerProcessor
+            loudnessCompensatorProc = loudnessCompensator
         } else {
             currentVol = _secondaryCurrentVolume
             // Secondary uses sine curve (0→1).
@@ -1242,6 +1300,8 @@ final class ProcessTapController: ProcessTapControlling {
             stereoRight = _secondaryPreferredStereoRightChannel
             eqProc = secondaryEQProcessor
             autoEQProc = secondaryAutoEQProcessor
+            loudnessEqualizerProc = secondaryLoudnessEqualizerProcessor
+            loudnessCompensatorProc = secondaryLoudnessCompensator
         }
 
         Self.processMappedBuffers(
@@ -1254,7 +1314,9 @@ final class ProcessTapController: ProcessTapControlling {
             preferredStereoRight: stereoRight,
             currentVol: &currentVol,
             eqProc: eqProc,
-            autoEQProc: autoEQProc
+            autoEQProc: autoEQProc,
+            loudnessEqualizerProc: loudnessEqualizerProc,
+            loudnessCompensatorProc: loudnessCompensatorProc
         )
 
         if isPrimary {

--- a/FineTune/Audio/Engine/ProcessTapControlling.swift
+++ b/FineTune/Audio/Engine/ProcessTapControlling.swift
@@ -21,6 +21,8 @@ protocol ProcessTapControlling: AnyObject {
     func updateEQSettings(_ settings: EQSettings)
     func updateAutoEQProfile(_ profile: AutoEQProfile?)
     func setAutoEQPreampEnabled(_ enabled: Bool)
+    func updateLoudnessCompensation(volume: Float, amount: Float, enabled: Bool)
+    func updateLoudnessEqualization(_ settings: LoudnessEqualizerSettings)
     func switchDevice(to newDeviceUID: String, preferredTapSourceDeviceUID: String?, sourceDeviceDead: Bool) async throws
     func updateDevices(to newDeviceUIDs: [String], preferredTapSourceDeviceUID: String?, sourceDeviceDead: Bool) async throws
     func hasRecentAudioCallback(within seconds: Double) -> Bool

--- a/FineTune/Audio/Loudness/GainComputer.swift
+++ b/FineTune/Audio/Loudness/GainComputer.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Computes the desired gain in dB given a smoothed loudness level.
+/// Pure, stateless value type — RT-safe.
+struct GainComputer: Sendable {
+    var settings: LoudnessEqualizerSettings
+
+    /// Returns the desired gain (dB) for a wideband leveler that boosts quiet material
+    /// and applies a gentle soft-knee cut to louder passages.
+    func desiredGainDb(forLevelDb smoothedLevelDb: Float) -> Float {
+        let boost = desiredBoostDb(forLevelDb: smoothedLevelDb)
+        let cut = desiredCutDb(forLevelDb: smoothedLevelDb)
+        return boost + cut
+    }
+
+    private func desiredBoostDb(forLevelDb smoothedLevelDb: Float) -> Float {
+        let raw = settings.targetLoudnessDb - smoothedLevelDb
+        var clamped = LoudnessEqualizerMath.clamp(raw, min: 0, max: settings.maxBoostDb)
+
+        // Step 3: noise-floor protection — cap upward gain when signal is very quiet
+        if smoothedLevelDb < settings.noiseFloorThresholdDb, clamped > 0 {
+            clamped = min(clamped, settings.lowLevelMaxBoostDb)
+        }
+
+        return clamped
+    }
+
+    private func desiredCutDb(forLevelDb smoothedLevelDb: Float) -> Float {
+        guard settings.maxCutDb > 0 else { return 0 }
+
+        let threshold = settings.targetLoudnessDb + settings.compressionThresholdOffsetDb
+        let ratio = max(settings.compressionRatio, 1)
+        let kneeWidth = max(settings.compressionKneeDb, 0)
+
+        let compressedLevel = softKneeCompressedLevel(
+            inputLevelDb: smoothedLevelDb,
+            thresholdDb: threshold,
+            ratio: ratio,
+            kneeWidthDb: kneeWidth
+        )
+        let gainReduction = compressedLevel - smoothedLevelDb
+        return LoudnessEqualizerMath.clamp(gainReduction, min: -settings.maxCutDb, max: 0)
+    }
+
+    private func softKneeCompressedLevel(
+        inputLevelDb: Float,
+        thresholdDb: Float,
+        ratio: Float,
+        kneeWidthDb: Float
+    ) -> Float {
+        guard ratio > 1 else { return inputLevelDb }
+
+        if kneeWidthDb <= 0 {
+            guard inputLevelDb > thresholdDb else { return inputLevelDb }
+            return thresholdDb + (inputLevelDb - thresholdDb) / ratio
+        }
+
+        let kneeHalfWidth = kneeWidthDb * 0.5
+        let kneeStart = thresholdDb - kneeHalfWidth
+        let kneeEnd = thresholdDb + kneeHalfWidth
+
+        if inputLevelDb <= kneeStart {
+            return inputLevelDb
+        }
+
+        if inputLevelDb >= kneeEnd {
+            return thresholdDb + (inputLevelDb - thresholdDb) / ratio
+        }
+
+        let normalizedDistance = inputLevelDb - kneeStart
+        let quadraticGain = (1 / ratio - 1) * normalizedDistance * normalizedDistance / (2 * kneeWidthDb)
+        return inputLevelDb + quadraticGain
+    }
+}

--- a/FineTune/Audio/Loudness/GainSmoother.swift
+++ b/FineTune/Audio/Loudness/GainSmoother.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Smooths gain changes using asymmetric attack/release time constants.
+/// Ticks once per analysis hop. RT-safe — no allocations in `process`.
+final class GainSmoother: @unchecked Sendable {
+    private var settings: LoudnessEqualizerSettings
+    private var attackCoeff: Float
+    private var releaseCoeff: Float
+    private(set) var currentGainDb: Float = 0
+
+    init(settings: LoudnessEqualizerSettings, sampleRate: Float) {
+        self.settings = settings
+        let hopMs = settings.analysisHopMs
+        self.attackCoeff  = LoudnessEqualizerMath.timeConstantCoefficient(timeMs: settings.gainAttackMs,  stepMs: hopMs)
+        self.releaseCoeff = LoudnessEqualizerMath.timeConstantCoefficient(timeMs: settings.gainReleaseMs, stepMs: hopMs)
+    }
+
+    /// Update settings and recompute coefficients.
+    func updateSettings(_ settings: LoudnessEqualizerSettings, sampleRate: Float) {
+        self.settings = settings
+        let hopMs = settings.analysisHopMs
+        self.attackCoeff  = LoudnessEqualizerMath.timeConstantCoefficient(timeMs: settings.gainAttackMs,  stepMs: hopMs)
+        self.releaseCoeff = LoudnessEqualizerMath.timeConstantCoefficient(timeMs: settings.gainReleaseMs, stepMs: hopMs)
+    }
+
+    /// Reset smoother to a known initial gain.
+    func reset(initialGainDb: Float = 0) {
+        currentGainDb = initialGainDb
+    }
+
+    /// Advance one hop toward `targetGainDb`. Returns the current smoothed gain.
+    func process(targetGainDb: Float) -> Float {
+        // Attack: target < current means gain is being reduced (signal got louder) — use faster coeff
+        // Release: target >= current means gain is recovering — use slower coeff
+        let coeff: Float = targetGainDb < currentGainDb ? attackCoeff : releaseCoeff
+        currentGainDb += coeff * (targetGainDb - currentGainDb)
+        return currentGainDb
+    }
+}

--- a/FineTune/Audio/Loudness/ISO226Contours.swift
+++ b/FineTune/Audio/Loudness/ISO226Contours.swift
@@ -1,0 +1,137 @@
+// FineTune/Audio/Loudness/ISO226Contours.swift
+import Foundation
+
+/// ISO 226:2023 equal-loudness contour utilities.
+///
+/// Normative contour computation uses ISO 226:2023 Formula (1) with Table 1
+/// coefficients. Any interpolation exposed here is deliberately kept separate
+/// from the normative contour calculation and is only used for fitting the
+/// 29-point contour to the app's fixed EQ band centers.
+enum ISO226Contours {
+
+    // MARK: - ISO 226:2023 Table 1
+
+    /// Preferred one-third-octave frequencies from 20 Hz to 12.5 kHz.
+    static let frequencies: [Double] = [
+        20, 25, 31.5, 40, 50, 63, 80, 100, 125, 160,
+        200, 250, 315, 400, 500, 630, 800, 1000, 1250, 1600,
+        2000, 2500, 3150, 4000, 5000, 6300, 8000, 10000, 12500
+    ]
+
+    /// ISO 226:2023 loudness perception exponent αf.
+    static let loudnessPerceptionExponents: [Double] = [
+        0.635, 0.602, 0.569, 0.537, 0.509, 0.482, 0.456, 0.433, 0.412, 0.391,
+        0.373, 0.357, 0.343, 0.330, 0.320, 0.311, 0.303, 0.300, 0.295, 0.292,
+        0.290, 0.290, 0.289, 0.289, 0.289, 0.293, 0.303, 0.323, 0.354
+    ]
+
+    /// ISO 226:2023 transfer-function magnitudes LU in dB.
+    static let transferMagnitudesDB: [Double] = [
+        -31.5, -27.2, -23.1, -19.3, -16.1, -13.1, -10.4, -8.2, -6.3, -4.6,
+        -3.2, -2.1, -1.2, -0.5, 0.0, 0.4, 0.5, 0.0, -2.7, -4.2,
+        -1.2, 1.4, 2.3, 1.0, -2.3, -7.2, -11.2, -10.9, -3.5
+    ]
+
+    /// ISO 226:2023 hearing thresholds Tf in dB.
+    /// The 20 Hz value reflects ISO 389-7:2019 and is 0.4 dB lower than 2003.
+    static let hearingThresholdsDB: [Double] = [
+        78.1, 68.7, 59.5, 51.1, 44.0, 37.5, 31.5, 26.5, 22.1, 17.9,
+        14.4, 11.4, 8.6, 6.2, 4.4, 3.0, 2.2, 2.4, 3.5, 1.7,
+        -1.3, -4.2, -6.0, -5.4, -1.5, 6.0, 12.6, 13.9, 12.3
+    ]
+
+    /// ISO 226:2023 reference loudness exponent αr at 1 kHz.
+    static let referenceLoudnessExponent: Double = 0.300
+    static let defaultReferencePhon: Double = 90.0
+
+    private static let referenceFrequencyIndex = 17
+    private static let referenceSoundPressureSquaredPa: Double = 4e-10
+    private static let supportedPhonRange = 20.0...90.0
+    private static let estimatedPhonRange = 20.0...defaultReferencePhon
+
+    // MARK: - Volume → Phon Mapping
+
+    /// App-specific system-volume heuristic, not defined by ISO 226.
+    static func estimatedPhon(fromSystemVolume volume: Float) -> Double {
+        let v = Double(max(0.0, min(1.0, volume)))
+        return estimatedPhonRange.lowerBound
+            + (defaultReferencePhon - estimatedPhonRange.lowerBound) * pow(v, 0.5)
+    }
+
+    // MARK: - Normative Contour Computation
+
+    /// Calculate the normative 29-point contour using ISO 226:2023 Formula (1).
+    ///
+    /// The ISO formula is normative from 20 phon upward for the app's use case,
+    /// so values are clamped to the supported range before evaluation.
+    static func contourSPL(atPhon phon: Double) -> [Double] {
+        let clampedPhon = min(max(phon, supportedPhonRange.lowerBound), supportedPhonRange.upperBound)
+        let referenceThresholdDB = hearingThresholdsDB[referenceFrequencyIndex]
+        return zip(loudnessPerceptionExponents, zip(transferMagnitudesDB, hearingThresholdsDB)).map {
+            alphaF, pair in
+            let (lu, tf) = pair
+
+            let excitation =
+                pow(referenceSoundPressureSquaredPa, referenceLoudnessExponent - alphaF) *
+                (pow(10.0, (referenceLoudnessExponent * clampedPhon) / 10.0) -
+                 pow(10.0, (referenceLoudnessExponent * referenceThresholdDB) / 10.0)) +
+                pow(10.0, (referenceLoudnessExponent * (tf + lu)) / 10.0)
+
+            return (10.0 / alphaF) * log10(excitation) - lu
+        }
+    }
+
+    /// Compute frequency-dependent loudness compensation relative to a reference phon level.
+    ///
+    /// The ISO contour math is kept intact; only the application-layer EQ derivation is
+    /// normalized around 1 kHz so the app compensates spectral balance without trying to
+    /// restore the overall lost loudness via broadband gain.
+    static func compensationGains(
+        atPhon phon: Double,
+        referencePhon: Double = defaultReferencePhon,
+        amount: Double = 1.0,
+        maxGainDB: Double = .greatestFiniteMagnitude
+    ) -> [Double] {
+        let clampedAmount = min(max(amount, 0.0), 1.0)
+        let referenceContour = contourSPL(atPhon: referencePhon)
+        let currentContour = contourSPL(atPhon: phon)
+        let referenceAtOneKilohertz = referenceContour[referenceFrequencyIndex]
+        let currentAtOneKilohertz = currentContour[referenceFrequencyIndex]
+
+        return zip(referenceContour, currentContour).map { reference, current in
+            let gain = ((current - currentAtOneKilohertz) - (reference - referenceAtOneKilohertz)) * clampedAmount
+            return max(-maxGainDB, min(maxGainDB, gain))
+        }
+    }
+
+    /// Required global attenuation to keep the largest positive boost at unity gain.
+    static func requiredHeadroomDB(forCompensationGains gains: [Double]) -> Double {
+        max(0.0, gains.max() ?? 0.0)
+    }
+
+    // MARK: - Non-normative Interpolation
+
+    /// Interpolate a 29-point compensation curve to an arbitrary frequency.
+    ///
+    /// This is not part of ISO 226. It exists only to fit the normative contour
+    /// to the app's fixed EQ centers and any future chart rendering.
+    static func interpolateCompensation(_ gains: [Double], atFrequency frequency: Double) -> Double {
+        guard gains.count == frequencies.count else { return 0.0 }
+
+        let logFrequency = log(frequency)
+        let logFrequencies = frequencies.map { log($0) }
+
+        if logFrequency <= logFrequencies.first! { return gains.first! }
+        if logFrequency >= logFrequencies.last! { return gains.last! }
+
+        var lowerIndex = 0
+        for index in 0..<(logFrequencies.count - 1) where logFrequencies[index + 1] >= logFrequency {
+            lowerIndex = index
+            break
+        }
+
+        let upperIndex = lowerIndex + 1
+        let t = (logFrequency - logFrequencies[lowerIndex]) / (logFrequencies[upperIndex] - logFrequencies[lowerIndex])
+        return gains[lowerIndex] + t * (gains[upperIndex] - gains[lowerIndex])
+    }
+}

--- a/FineTune/Audio/Loudness/KWeightingFilter.swift
+++ b/FineTune/Audio/Loudness/KWeightingFilter.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// ITU-R BS.1770 K-weighting pre-filter for loudness measurement.
+///
+/// Two biquad stages in series:
+///   Stage 1 — High-shelf pre-emphasis (+4 dB at ~1.5 kHz)
+///   Stage 2 — High-pass RLB weighting (2nd-order Butterworth, ~38 Hz)
+///
+/// Implemented as transposed direct-form II with scalar state fields for RT-safety.
+/// No allocations occur in `processSample`.
+final class KWeightingFilter: @unchecked Sendable {
+
+    // MARK: - Coefficient storage (Double precision for accuracy)
+
+    // Stage 1: high-shelf  [b0, b1, b2, a1, a2]
+    private var s1_b0: Float = 1
+    private var s1_b1: Float = 0
+    private var s1_b2: Float = 0
+    private var s1_a1: Float = 0
+    private var s1_a2: Float = 0
+
+    // Stage 2: high-pass   [b0, b1, b2, a1, a2]
+    private var s2_b0: Float = 1
+    private var s2_b1: Float = 0
+    private var s2_b2: Float = 0
+    private var s2_a1: Float = 0
+    private var s2_a2: Float = 0
+
+    // MARK: - State (transposed direct-form II delay elements)
+
+    private var s1_z1: Float = 0
+    private var s1_z2: Float = 0
+
+    private var s2_z1: Float = 0
+    private var s2_z2: Float = 0
+
+    // MARK: - Initialisation
+
+    init(sampleRate: Float) {
+        computeCoefficients(sampleRate: Double(sampleRate))
+    }
+
+    // MARK: - Public API
+
+    /// Process a single sample through both K-weighting stages.
+    /// Allocation-free, side-effect-free.
+    @inline(__always)
+    func processSample(_ sample: Float) -> Float {
+        // Stage 1 — high-shelf
+        let y1 = s1_b0 * sample + s1_z1
+        let nextS1Z1 = s1_b1 * sample - s1_a1 * y1 + s1_z2
+        let nextS1Z2 = s1_b2 * sample - s1_a2 * y1
+        s1_z1 = nextS1Z1
+        s1_z2 = nextS1Z2
+
+        // Stage 2 — high-pass
+        let y2 = s2_b0 * y1 + s2_z1
+        let nextS2Z1 = s2_b1 * y1 - s2_a1 * y2 + s2_z2
+        let nextS2Z2 = s2_b2 * y1 - s2_a2 * y2
+        s2_z1 = nextS2Z1
+        s2_z2 = nextS2Z2
+
+        return y2
+    }
+
+    /// Update coefficients for a new sample rate. Resets filter state.
+    func updateSampleRate(_ sampleRate: Float) {
+        computeCoefficients(sampleRate: Double(sampleRate))
+        reset()
+    }
+
+    /// Reset all filter state to zero.
+    func reset() {
+        s1_z1 = 0; s1_z2 = 0
+        s2_z1 = 0; s2_z2 = 0
+    }
+
+    // MARK: - Private helpers
+
+    private func computeCoefficients(sampleRate: Double) {
+        // Stage 1: high-shelf  +4 dB at 1500 Hz, Q = 1/√2
+        let shelfCoeffs = BiquadMath.highShelfCoefficients(
+            frequency: 1500.0,
+            gainDB: 4.0,
+            q: 1.0 / sqrt(2.0),
+            sampleRate: sampleRate
+        )
+        s1_b0 = Float(shelfCoeffs[0])
+        s1_b1 = Float(shelfCoeffs[1])
+        s1_b2 = Float(shelfCoeffs[2])
+        s1_a1 = Float(shelfCoeffs[3])
+        s1_a2 = Float(shelfCoeffs[4])
+
+        // Stage 2: high-pass  38 Hz, Q = 0.5 (Butterworth)
+        let hpCoeffs = BiquadMath.highPassCoefficients(
+            frequency: 38.0,
+            q: 0.5,
+            sampleRate: sampleRate
+        )
+        s2_b0 = Float(hpCoeffs[0])
+        s2_b1 = Float(hpCoeffs[1])
+        s2_b2 = Float(hpCoeffs[2])
+        s2_a1 = Float(hpCoeffs[3])
+        s2_a2 = Float(hpCoeffs[4])
+    }
+}

--- a/FineTune/Audio/Loudness/LoudnessCompensator.swift
+++ b/FineTune/Audio/Loudness/LoudnessCompensator.swift
@@ -1,0 +1,355 @@
+// FineTune/Audio/Loudness/LoudnessCompensator.swift
+import Foundation
+import Accelerate
+
+/// RT-safe loudness compensation processor based on ISO 226:2023 equal-loudness contours.
+///
+/// Applies frequency-dependent gain to counteract the human ear's reduced sensitivity
+/// to bass and treble at low listening levels. At the reference level (~90 phon),
+/// compensation is flat (bypassed). At lower levels, the contour difference is
+/// normalized around 1 kHz so only spectral balance is corrected. The app then fits
+/// that target curve with a low-cost four-section shelf/bell cascade, and a matching
+/// preamp creates headroom equal to the fitted cascade's true peak boost.
+///
+/// Subclass of `BiquadProcessor` — inherits atomic setup swaps, stereo biquad processing,
+/// delay buffer management, and NaN safety. Follows the same pattern as `EQProcessor`.
+final class LoudnessCompensator: BiquadProcessor, @unchecked Sendable {
+
+    // MARK: - Configuration
+
+    /// Four-section topology chosen to approximate the ISO-derived loudness target with
+    /// minimal runtime DSP cost: low shelf, low-mid bell, upper-mid bell, high shelf.
+    private enum LoudnessFilterKind {
+        case lowShelf
+        case peaking
+        case highShelf
+    }
+
+    private struct LoudnessFilterDefinition {
+        let kind: LoudnessFilterKind
+        let frequency: Double
+        let q: Double
+    }
+
+    private static let filterDefinitions: [LoudnessFilterDefinition] = [
+        .init(kind: .lowShelf, frequency: 80, q: 0.707),
+        .init(kind: .peaking, frequency: 180, q: 0.7),
+        .init(kind: .peaking, frequency: 3200, q: 0.7),
+        .init(kind: .highShelf, frequency: 10000, q: 0.85),
+    ]
+    static let bandFrequencies = filterDefinitions.map(\.frequency)
+    static let bandCount = filterDefinitions.count
+
+    private static let fitGridPointCount = 96
+    private static let fitIterationCount = 3
+
+    // MARK: - State
+
+    /// Phon level used for the last coefficient computation.
+    private var _currentPhon: Double = 80.0
+    private var _currentAmount: Double = 1.0
+    private nonisolated(unsafe) var _preampLinear: Float = 1.0
+
+    // MARK: - Init
+
+    init(sampleRate: Double) {
+        super.init(
+            sampleRate: sampleRate,
+            maxSections: Self.bandCount,
+            category: "LoudnessCompensator",
+            initiallyEnabled: false
+        )
+    }
+
+    // MARK: - Volume Update
+
+    /// Update compensation coefficients for a new system volume level.
+    ///
+    /// Converts volume → estimated phon, skips recomputation if phon changed by less
+    /// than 1.0 (coalesces rapid slider drags), bypasses processor when at reference level.
+    ///
+    /// Call from main thread only.
+    func updateForVolume(_ systemVolume: Float, amount: Float = 1.0) {
+        let phon = ISO226Contours.estimatedPhon(fromSystemVolume: systemVolume)
+        let clampedAmount = Double(min(max(amount, 0.0), 1.0))
+
+        // Coalesce rapid updates, but never skip a disabled processor because re-enabling
+        // loudness from the UI must rebuild coefficients immediately even at the same volume.
+        guard !isEnabled || abs(phon - _currentPhon) >= 1.0 || abs(clampedAmount - _currentAmount) >= 0.001 else { return }
+        _currentPhon = phon
+        _currentAmount = clampedAmount
+
+        let gains = computeBandGains(phon: phon, amount: clampedAmount)
+        let headroomDB = Self.requiredHeadroomDB(forBandGains: gains, sampleRate: sampleRate)
+
+        // Bypass when all gains are negligible (near reference level)
+        let allNegligible = gains.allSatisfy { abs($0) < 0.1 }
+        if allNegligible {
+            _preampLinear = 1.0
+            setEnabled(false)
+            swapSetup(nil)
+            return
+        }
+
+        _preampLinear = Self.preampLinearGain(forHeadroomDB: headroomDB)
+
+        let coefficients = Self.coefficientsForBands(gains: gains, sampleRate: sampleRate)
+        let newSetup = coefficients.withUnsafeBufferPointer { ptr in
+            vDSP_biquad_CreateSetup(ptr.baseAddress!, vDSP_Length(Self.bandCount))
+        }
+        swapSetup(newSetup)
+        setEnabled(true)
+    }
+
+    // MARK: - Coefficient Computation
+
+    /// Compute per-section gains (dB) for the fixed four-filter loudness topology.
+    private func computeBandGains(phon: Double, amount: Double) -> [Float] {
+        Self.fittedSectionGains(forPhon: phon, amount: amount, sampleRate: sampleRate)
+    }
+
+    /// Fit the fixed four-section loudness topology to the ISO-derived target curve.
+    static func fittedSectionGains(forPhon phon: Double, amount: Double = 1.0, sampleRate: Double) -> [Float] {
+        let targetCurve = targetCurveDB(forPhon: phon, amount: amount)
+        let basisResponses = basisResponsesDB(sampleRate: sampleRate)
+        let gramMatrix = gramMatrix(for: basisResponses)
+
+        var sectionGains = [Double](repeating: 0.0, count: bandCount)
+        for _ in 0..<fitIterationCount {
+            let realized = realizedResponseDB(sectionGains: sectionGains, sampleRate: sampleRate)
+            let residual = zip(targetCurve, realized).map { target, fitted in
+                target - fitted
+            }
+            let rhs = basisResponses.map { basis in
+                zip(basis, residual).reduce(0.0) { partial, pair in
+                    partial + pair.0 * pair.1
+                }
+            }
+            guard let delta = solveLinearSystem(gramMatrix, rhs: rhs) else { break }
+            for index in 0..<bandCount {
+                sectionGains[index] += delta[index]
+            }
+        }
+
+        return sectionGains.map(Float.init)
+    }
+
+    static func requiredHeadroomDB(forBandGains gains: [Float]) -> Double {
+        requiredHeadroomDB(forBandGains: gains, sampleRate: 48_000)
+    }
+
+    static func requiredHeadroomDB(forBandGains gains: [Float], sampleRate: Double) -> Double {
+        let coefficients = coefficientsForBands(gains: gains, sampleRate: sampleRate)
+        return peakCascadeResponseDB(coefficients: coefficients, sectionCount: bandCount, sampleRate: sampleRate)
+    }
+
+    private static func preampLinearGain(forHeadroomDB headroomDB: Double) -> Float {
+        Float(pow(10.0, -headroomDB / 20.0))
+    }
+
+    /// Build the flat coefficient array for `vDSP_biquad_CreateSetup`.
+    static func coefficientsForBands(gains: [Float], sampleRate: Double) -> [Double] {
+        guard gains.count == bandCount else {
+            return (0..<bandCount).flatMap { _ in [1.0, 0.0, 0.0, 0.0, 0.0] }
+        }
+
+        var allCoeffs: [Double] = []
+        allCoeffs.reserveCapacity(bandCount * 5)
+        for (index, filter) in filterDefinitions.enumerated() {
+            guard filter.frequency < sampleRate / 2.0 else {
+                allCoeffs.append(contentsOf: [1.0, 0.0, 0.0, 0.0, 0.0])
+                continue
+            }
+            let coeffs: [Double]
+            switch filter.kind {
+            case .lowShelf:
+                coeffs = BiquadMath.lowShelfCoefficients(
+                    frequency: filter.frequency,
+                    gainDB: gains[index],
+                    q: filter.q,
+                    sampleRate: sampleRate
+                )
+            case .peaking:
+                coeffs = BiquadMath.peakingEQCoefficients(
+                    frequency: filter.frequency,
+                    gainDB: gains[index],
+                    q: filter.q,
+                    sampleRate: sampleRate
+                )
+            case .highShelf:
+                coeffs = BiquadMath.highShelfCoefficients(
+                    frequency: filter.frequency,
+                    gainDB: gains[index],
+                    q: filter.q,
+                    sampleRate: sampleRate
+                )
+            }
+            allCoeffs.append(contentsOf: coeffs)
+        }
+        return allCoeffs
+    }
+
+    // MARK: - BiquadProcessor Overrides
+
+    override func recomputeCoefficients() -> (coefficients: [Double], sectionCount: Int)? {
+        // Called by updateSampleRate() — recompute for current phon at new sample rate
+        let gains = computeBandGains(phon: _currentPhon, amount: _currentAmount)
+        let allNegligible = gains.allSatisfy { abs($0) < 0.1 }
+        guard !allNegligible else {
+            _preampLinear = 1.0
+            return nil
+        }
+        _preampLinear = Self.preampLinearGain(
+            forHeadroomDB: Self.requiredHeadroomDB(forBandGains: gains, sampleRate: sampleRate)
+        )
+        let coefficients = Self.coefficientsForBands(gains: gains, sampleRate: sampleRate)
+        return (coefficients, Self.bandCount)
+    }
+
+    private static func peakCascadeResponseDB(coefficients: [Double], sectionCount: Int, sampleRate: Double) -> Double {
+        var peakDB = 0.0
+
+        for sampleIndex in 0..<1024 {
+            let frequency = 20.0 * pow(20_000.0 / 20.0, Double(sampleIndex) / 1023.0)
+            let omega = 2.0 * Double.pi * frequency / sampleRate
+            let magnitude = cascadeMagnitude(coefficients: coefficients, sectionCount: sectionCount, omega: omega)
+            peakDB = max(peakDB, 20.0 * log10(magnitude))
+        }
+
+        return max(0.0, peakDB)
+    }
+
+    private static func cascadeMagnitude(coefficients: [Double], sectionCount: Int, omega: Double) -> Double {
+        let cosW = cos(omega)
+        let sinW = sin(omega)
+        let cos2W = cos(2.0 * omega)
+        let sin2W = sin(2.0 * omega)
+
+        var magnitude = 1.0
+        for offset in stride(from: 0, to: sectionCount * 5, by: 5) {
+            let numeratorReal = coefficients[offset] + coefficients[offset + 1] * cosW + coefficients[offset + 2] * cos2W
+            let numeratorImag = -(coefficients[offset + 1] * sinW + coefficients[offset + 2] * sin2W)
+            let denominatorReal = 1.0 + coefficients[offset + 3] * cosW + coefficients[offset + 4] * cos2W
+            let denominatorImag = -(coefficients[offset + 3] * sinW + coefficients[offset + 4] * sin2W)
+
+            let numeratorMagnitudeSquared = numeratorReal * numeratorReal + numeratorImag * numeratorImag
+            let denominatorMagnitudeSquared = denominatorReal * denominatorReal + denominatorImag * denominatorImag
+            magnitude *= sqrt(numeratorMagnitudeSquared / denominatorMagnitudeSquared)
+        }
+
+        return magnitude
+    }
+
+    private static func targetCurveDB(forPhon phon: Double, amount: Double) -> [Double] {
+        let compensation = ISO226Contours.compensationGains(atPhon: phon, amount: amount)
+        let fitFrequencies = fitGridFrequencies()
+        return fitFrequencies.map { frequency in
+            ISO226Contours.interpolateCompensation(compensation, atFrequency: frequency)
+        }
+    }
+
+    private static func basisResponsesDB(sampleRate: Double) -> [[Double]] {
+        let fitFrequencies = fitGridFrequencies()
+        return filterDefinitions.map { filter in
+            let coefficients: [Double]
+            switch filter.kind {
+            case .lowShelf:
+                coefficients = BiquadMath.lowShelfCoefficients(
+                    frequency: filter.frequency,
+                    gainDB: 1.0,
+                    q: filter.q,
+                    sampleRate: sampleRate
+                )
+            case .peaking:
+                coefficients = BiquadMath.peakingEQCoefficients(
+                    frequency: filter.frequency,
+                    gainDB: 1.0,
+                    q: filter.q,
+                    sampleRate: sampleRate
+                )
+            case .highShelf:
+                coefficients = BiquadMath.highShelfCoefficients(
+                    frequency: filter.frequency,
+                    gainDB: 1.0,
+                    q: filter.q,
+                    sampleRate: sampleRate
+                )
+            }
+
+            return fitFrequencies.map { frequency in
+                let omega = 2.0 * Double.pi * frequency / sampleRate
+                return 20.0 * log10(cascadeMagnitude(coefficients: coefficients, sectionCount: 1, omega: omega))
+            }
+        }
+    }
+
+    private static func realizedResponseDB(sectionGains: [Double], sampleRate: Double) -> [Double] {
+        let coefficients = coefficientsForBands(gains: sectionGains.map(Float.init), sampleRate: sampleRate)
+        return fitGridFrequencies().map { frequency in
+            let omega = 2.0 * Double.pi * frequency / sampleRate
+            return 20.0 * log10(cascadeMagnitude(coefficients: coefficients, sectionCount: bandCount, omega: omega))
+        }
+    }
+
+    private static func fitGridFrequencies() -> [Double] {
+        (0..<fitGridPointCount).map { index in
+            20.0 * pow(20_000.0 / 20.0, Double(index) / Double(fitGridPointCount - 1))
+        }
+    }
+
+    private static func gramMatrix(for basisResponses: [[Double]]) -> [[Double]] {
+        (0..<bandCount).map { row in
+            (0..<bandCount).map { column in
+                zip(basisResponses[row], basisResponses[column]).reduce(0.0) { partial, pair in
+                    partial + pair.0 * pair.1
+                }
+            }
+        }
+    }
+
+    private static func solveLinearSystem(_ matrix: [[Double]], rhs: [Double]) -> [Double]? {
+        var augmented = matrix.enumerated().map { index, row in
+            row + [rhs[index]]
+        }
+        let size = rhs.count
+
+        for pivotIndex in 0..<size {
+            let bestPivotIndex = (pivotIndex..<size).max { lhs, rhsIndex in
+                abs(augmented[lhs][pivotIndex]) < abs(augmented[rhsIndex][pivotIndex])
+            } ?? pivotIndex
+
+            guard abs(augmented[bestPivotIndex][pivotIndex]) > 1e-12 else {
+                return nil
+            }
+
+            if bestPivotIndex != pivotIndex {
+                augmented.swapAt(bestPivotIndex, pivotIndex)
+            }
+
+            let pivot = augmented[pivotIndex][pivotIndex]
+            for column in pivotIndex...size {
+                augmented[pivotIndex][column] /= pivot
+            }
+
+            for row in 0..<size where row != pivotIndex {
+                let factor = augmented[row][pivotIndex]
+                guard factor != 0 else { continue }
+                for column in pivotIndex...size {
+                    augmented[row][column] -= factor * augmented[pivotIndex][column]
+                }
+            }
+        }
+
+        return (0..<size).map { augmented[$0][size] }
+    }
+
+    override func preProcess(output: UnsafeMutablePointer<Float>, frameCount: Int) {
+        let preampLinear = _preampLinear
+        guard preampLinear != 1.0 else { return }
+
+        let sampleCount = frameCount * 2
+        for sampleIndex in 0..<sampleCount {
+            output[sampleIndex] *= preampLinear
+        }
+    }
+}

--- a/FineTune/Audio/Loudness/LoudnessDetector.swift
+++ b/FineTune/Audio/Loudness/LoudnessDetector.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Measures signal loudness using a ring-buffer RMS estimator and applies
+/// asymmetric attack/release envelope smoothing in the dB domain.
+///
+/// Thread-safety: all mutation must occur on a single real-time audio thread.
+/// The class is marked @unchecked Sendable because its mutable state is
+/// exclusively owned by that thread.
+final class LoudnessDetector: @unchecked Sendable {
+
+    // MARK: - Private state
+
+    private var settings: LoudnessEqualizerSettings
+    private var sampleRate: Float
+
+    // Ring buffer (stores squared samples)
+    private var ringBuffer: [Float]
+    private var writeIndex: Int = 0
+    private var hopCounter: Int = 0
+    private var runningSquareSum: Float = 0
+
+    // Derived sizes
+    private var windowSamples: Int
+    private var inverseWindowSamples: Float
+    private var hopSamples: Int
+
+    // Envelope coefficients
+    private var attackCoeff: Float
+    private var releaseCoeff: Float
+
+    // Smoothed level in dB
+    private var smoothedLevel: Float = -120.0
+
+    // MARK: - Init
+
+    init(settings: LoudnessEqualizerSettings, sampleRate: Float) {
+        self.settings = settings
+        self.sampleRate = sampleRate
+
+        let ws = Int(settings.analysisWindowMs / 1000 * sampleRate)
+        windowSamples = max(ws, 1)
+        inverseWindowSamples = 1.0 / Float(windowSamples)
+
+        let hs = Int(settings.analysisHopMs / 1000 * sampleRate)
+        hopSamples = max(hs, 1)
+
+        ringBuffer = [Float](repeating: 0, count: windowSamples)
+
+        attackCoeff = LoudnessEqualizerMath.timeConstantCoefficient(
+            timeMs: settings.detectorAttackMs,
+            stepMs: settings.analysisHopMs
+        )
+        releaseCoeff = LoudnessEqualizerMath.timeConstantCoefficient(
+            timeMs: settings.detectorReleaseMs,
+            stepMs: settings.analysisHopMs
+        )
+    }
+
+    // MARK: - Real-time ingest
+
+    /// Ingest one K-weighted sample. Returns a new smoothed level (dB) when a
+    /// hop boundary is reached, otherwise returns nil.
+    /// RT-safe: no allocations, no logging, no ObjC.
+    func ingest(weightedSample: Float) -> Float? {
+        // Update running sum: subtract old squared value, store new squared value, add it
+        runningSquareSum -= ringBuffer[writeIndex]
+        ringBuffer[writeIndex] = weightedSample * weightedSample
+        runningSquareSum += ringBuffer[writeIndex]
+
+        writeIndex += 1
+        if writeIndex == windowSamples {
+            writeIndex = 0
+        }
+
+        hopCounter += 1
+        if hopCounter >= hopSamples {
+            hopCounter = 0
+            let meanSquare = runningSquareSum * inverseWindowSamples
+            let levelDb = LoudnessEqualizerMath.meanSquareToDb(meanSquare)
+            return updateEnvelope(with: levelDb)
+        }
+        return nil
+    }
+
+    // MARK: - Envelope smoothing
+
+    /// Apply asymmetric attack/release smoothing. Returns the updated smoothed level.
+    func updateEnvelope(with measuredLevelDb: Float) -> Float {
+        let coeff: Float
+        if measuredLevelDb > smoothedLevel {
+            coeff = attackCoeff
+        } else {
+            coeff = releaseCoeff
+        }
+        smoothedLevel += coeff * (measuredLevelDb - smoothedLevel)
+        return smoothedLevel
+    }
+
+    // MARK: - Settings update
+
+    func updateSettings(_ settings: LoudnessEqualizerSettings, sampleRate: Float) {
+        self.settings = settings
+        self.sampleRate = sampleRate
+
+        let ws = Int(settings.analysisWindowMs / 1000 * sampleRate)
+        let newWindowSamples = max(ws, 1)
+
+        let hs = Int(settings.analysisHopMs / 1000 * sampleRate)
+        hopSamples = max(hs, 1)
+
+        if newWindowSamples != windowSamples {
+            windowSamples = newWindowSamples
+            inverseWindowSamples = 1.0 / Float(windowSamples)
+            ringBuffer = [Float](repeating: 0, count: windowSamples)
+            writeIndex = 0
+            hopCounter = 0
+            runningSquareSum = 0
+        }
+
+        attackCoeff = LoudnessEqualizerMath.timeConstantCoefficient(
+            timeMs: settings.detectorAttackMs,
+            stepMs: settings.analysisHopMs
+        )
+        releaseCoeff = LoudnessEqualizerMath.timeConstantCoefficient(
+            timeMs: settings.detectorReleaseMs,
+            stepMs: settings.analysisHopMs
+        )
+    }
+
+    // MARK: - Reset
+
+    func reset() {
+        for i in 0..<ringBuffer.count {
+            ringBuffer[i] = 0
+        }
+        writeIndex = 0
+        hopCounter = 0
+        runningSquareSum = 0
+        smoothedLevel = -120.0
+    }
+}

--- a/FineTune/Audio/Loudness/LoudnessEqualizer.swift
+++ b/FineTune/Audio/Loudness/LoudnessEqualizer.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// Loudness equalizer that applies K-weighted loudness measurement and
+/// asymmetric gain smoothing to keep perceived loudness near a target level.
+///
+/// Input/output memory layout: interleaved — frame-major ordering.
+///   `output[f * channelCount + ch]`
+///
+/// All mutable state is owned exclusively by the real-time audio thread.
+/// The class is marked @unchecked Sendable accordingly.
+final class LoudnessEqualizer: @unchecked Sendable {
+
+    // MARK: - Private state
+
+    private var settings: LoudnessEqualizerSettings
+    private var currentSampleRate: Float
+    private let kFilter: KWeightingFilter
+    private let detector: LoudnessDetector
+    private var gainComputer: GainComputer
+    private let gainSmoother: GainSmoother
+    private var currentLinearGain: Float = 1.0
+
+    // MARK: - Init
+
+    init(settings: LoudnessEqualizerSettings, sampleRate: Float, channelCount: Int) {
+        self.settings = settings
+        self.currentSampleRate = sampleRate
+        self.kFilter = KWeightingFilter(sampleRate: sampleRate)
+        self.detector = LoudnessDetector(settings: settings, sampleRate: sampleRate)
+        self.gainComputer = GainComputer(settings: settings)
+        self.gainSmoother = GainSmoother(settings: settings, sampleRate: sampleRate)
+        self.currentLinearGain = LoudnessEqualizerMath.dbToLinear(self.gainSmoother.currentGainDb)
+    }
+
+    // MARK: - Public API
+
+    /// Whether loudness processing is active.
+    var isEnabled: Bool { settings.enabled }
+
+    /// The current settings snapshot.
+    var currentSettings: LoudnessEqualizerSettings { settings }
+
+    /// Process audio from an interleaved input buffer to an interleaved output buffer.
+    ///
+    /// - Parameters:
+    ///   - input:        Interleaved input: `input[f * channelCount + ch]`
+    ///   - output:       Interleaved output: `output[f * channelCount + ch]`
+    ///   - frameCount:   Number of frames per channel.
+    ///   - channelCount: Number of channels.
+    ///
+    /// RT-safe: allocation-free, no logging.
+    func process(
+        input: UnsafePointer<Float>,
+        output: UnsafeMutablePointer<Float>,
+        frameCount: Int,
+        channelCount: Int
+    ) {
+        let enabled = settings.enabled
+        if !enabled {
+            if input != UnsafePointer(output) {
+                memcpy(output, input, frameCount * channelCount * MemoryLayout<Float>.size)
+            }
+            return
+        }
+
+        var linearGain = currentLinearGain
+
+        if channelCount == 2 {
+            for frame in 0..<frameCount {
+                let base = frame * 2
+                let mono = (input[base] + input[base + 1]) * 0.5
+                let weighted = kFilter.processSample(mono)
+
+                if let newLevel = detector.ingest(weightedSample: weighted) {
+                    let desiredGain = gainComputer.desiredGainDb(forLevelDb: newLevel)
+                    let smoothedGain = gainSmoother.process(targetGainDb: desiredGain)
+                    linearGain = LoudnessEqualizerMath.dbToLinear(smoothedGain)
+                    currentLinearGain = linearGain
+                }
+
+                output[base] = input[base] * linearGain
+                output[base + 1] = input[base + 1] * linearGain
+            }
+            return
+        }
+
+        let inverseChannelCount = 1.0 / Float(channelCount)
+        for f in 0..<frameCount {
+            let base = f * channelCount
+
+            // --- Sidechain: downmix to mono (interleaved layout) ---
+            var mono: Float = 0
+            for ch in 0..<channelCount {
+                mono += input[base + ch]
+            }
+            mono *= inverseChannelCount
+
+            // --- K-weighting ---
+            let weighted = kFilter.processSample(mono)
+
+            // --- Detector ---
+            if let newLevel = detector.ingest(weightedSample: weighted) {
+                let desiredGain = gainComputer.desiredGainDb(forLevelDb: newLevel)
+                let smoothedGain = gainSmoother.process(targetGainDb: desiredGain)
+                linearGain = LoudnessEqualizerMath.dbToLinear(smoothedGain)
+                currentLinearGain = linearGain
+            }
+
+            // --- Apply gain to all channels ---
+            for ch in 0..<channelCount {
+                output[base + ch] = input[base + ch] * linearGain
+            }
+        }
+    }
+
+    /// Replace the current settings and propagate to sub-processors.
+    func updateSettings(_ settings: LoudnessEqualizerSettings) {
+        let wasEnabled = self.settings.enabled
+        self.settings = settings
+        gainComputer.settings = settings
+        detector.updateSettings(settings, sampleRate: currentSampleRate)
+        gainSmoother.updateSettings(settings, sampleRate: currentSampleRate)
+        if wasEnabled != settings.enabled || !settings.enabled {
+            reset()
+        }
+    }
+
+    /// Notify the equalizer that the host sample rate has changed.
+    func updateSampleRate(_ sampleRate: Float) {
+        currentSampleRate = sampleRate
+        kFilter.updateSampleRate(sampleRate)
+        detector.updateSettings(settings, sampleRate: sampleRate)
+        gainSmoother.updateSettings(settings, sampleRate: sampleRate)
+    }
+
+    /// Reset all internal state to initial conditions.
+    func reset() {
+        kFilter.reset()
+        detector.reset()
+        gainSmoother.reset()
+        currentLinearGain = 1.0
+    }
+}

--- a/FineTune/Audio/Loudness/LoudnessEqualizerMath.swift
+++ b/FineTune/Audio/Loudness/LoudnessEqualizerMath.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum LoudnessEqualizerMath {
+    static func dbToLinear(_ db: Float) -> Float {
+        pow(10, db / 20)
+    }
+
+    static func linearToDb(_ linear: Float) -> Float {
+        20 * log10(max(linear, 1e-9))
+    }
+
+    static func meanSquareToDb(_ meanSquare: Float) -> Float {
+        10 * log10(max(meanSquare, 1e-12))
+    }
+
+    static func rmsFromMeanSquare(_ meanSquare: Float) -> Float {
+        sqrt(max(meanSquare, 0))
+    }
+
+    static func clamp(_ value: Float, min: Float, max: Float) -> Float {
+        Swift.min(Swift.max(value, min), max)
+    }
+
+    static func timeConstantCoefficient(timeMs: Float, stepMs: Float) -> Float {
+        1 - exp(-stepMs / max(timeMs, 1e-6))
+    }
+}

--- a/FineTune/Audio/Loudness/LoudnessEqualizerSettings.swift
+++ b/FineTune/Audio/Loudness/LoudnessEqualizerSettings.swift
@@ -1,0 +1,23 @@
+struct LoudnessEqualizerSettings: Codable, Equatable, Sendable {
+    var targetLoudnessDb: Float = -12
+    var maxBoostDb: Float = 15
+    var maxCutDb: Float = 4
+    var compressionThresholdOffsetDb: Float = 6
+    var compressionRatio: Float = 1.6
+    var compressionKneeDb: Float = 8
+
+    var analysisWindowMs: Float = 30
+    var analysisHopMs: Float = 15
+
+    var detectorAttackMs: Float = 25
+    var detectorReleaseMs: Float = 400
+
+    var gainAttackMs: Float = 180
+    var gainReleaseMs: Float = 5000
+
+    var noiseFloorThresholdDb: Float = -48
+    var lowLevelMaxBoostDb: Float = 1.5
+
+    var limiterCeilingDb: Float = -1
+    var enabled: Bool = false
+}

--- a/FineTune/Settings/SettingsManager.swift
+++ b/FineTune/Settings/SettingsManager.swift
@@ -64,7 +64,17 @@ struct AppSettings: Codable, Equatable {
     // Notifications
     var showDeviceDisconnectAlerts: Bool = true
 
+    // Audio Processing
+    var loudnessCompensationEnabled: Bool = false  // ISO 226:2023 equal-loudness contour compensation
+    var loudnessCompensationAmount: Float = 1.0    // 0...1 strength multiplier for compensation contour
+    var loudnessEqualizationEnabled: Bool = false  // Real-time loudness equalization
+
     init() {}
+
+    mutating func setUnifiedLoudnessEnabled(_ enabled: Bool) {
+        loudnessCompensationEnabled = enabled
+        loudnessEqualizationEnabled = enabled
+    }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -74,6 +84,12 @@ struct AppSettings: Codable, Equatable {
         lockInputDevice = try c.decodeIfPresent(Bool.self, forKey: .lockInputDevice) ?? true
         softwareDeviceVolumeEnabled = try c.decodeIfPresent(Bool.self, forKey: .softwareDeviceVolumeEnabled) ?? false
         showDeviceDisconnectAlerts = try c.decodeIfPresent(Bool.self, forKey: .showDeviceDisconnectAlerts) ?? true
+        loudnessCompensationEnabled = try c.decodeIfPresent(Bool.self, forKey: .loudnessCompensationEnabled) ?? false
+        loudnessCompensationAmount = min(
+            max(try c.decodeIfPresent(Float.self, forKey: .loudnessCompensationAmount) ?? 1.0, 0.0),
+            1.0
+        )
+        loudnessEqualizationEnabled = try c.decodeIfPresent(Bool.self, forKey: .loudnessEqualizationEnabled) ?? false
     }
 }
 

--- a/FineTune/Views/MenuBarPopupView.swift
+++ b/FineTune/Views/MenuBarPopupView.swift
@@ -161,6 +161,15 @@ struct MenuBarPopupView: View {
             if oldValue.softwareDeviceVolumeEnabled != newValue.softwareDeviceVolumeEnabled {
                 audioEngine.handleSoftwareVolumeSettingChanged()
             }
+            if oldValue.loudnessCompensationEnabled != newValue.loudnessCompensationEnabled {
+                audioEngine.setLoudnessCompensationEnabled(newValue.loudnessCompensationEnabled)
+            }
+            if oldValue.loudnessCompensationAmount != newValue.loudnessCompensationAmount {
+                audioEngine.setLoudnessCompensationAmount(newValue.loudnessCompensationAmount)
+            }
+            if oldValue.loudnessEqualizationEnabled != newValue.loudnessEqualizationEnabled {
+                audioEngine.setLoudnessEqualizationEnabled(newValue.loudnessEqualizationEnabled)
+            }
         }
         .onChange(of: audioEngine.bluetoothDeviceMonitor.pairedDevices) { _, newValue in
             pairedDevices = newValue

--- a/FineTune/Views/Settings/SettingsLoudnessCompensationRow.swift
+++ b/FineTune/Views/Settings/SettingsLoudnessCompensationRow.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// Combined settings row for loudness compensation toggle and amount slider.
+struct SettingsLoudnessCompensationRow: View {
+    @Binding var isOn: Bool
+    @Binding var amount: Float
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
+            HStack(spacing: DesignTokens.Spacing.md) {
+                Image(systemName: "ear")
+                    .font(.system(size: DesignTokens.Dimensions.iconSizeSmall))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(DesignTokens.Colors.interactiveDefault)
+                    .frame(width: DesignTokens.Dimensions.settingsIconWidth, alignment: .center)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Loudness Equalization")
+                        .font(DesignTokens.Typography.rowName)
+                        .foregroundStyle(DesignTokens.Colors.textPrimary)
+
+                    Text("Maintains tonal balance at low listening levels")
+                        .font(DesignTokens.Typography.caption)
+                        .foregroundStyle(DesignTokens.Colors.textTertiary)
+                        .lineLimit(2)
+                }
+
+                Spacer(minLength: DesignTokens.Spacing.sm)
+
+                Toggle("", isOn: $isOn)
+                    .toggleStyle(.switch)
+                    .scaleEffect(0.8)
+                    .labelsHidden()
+            }
+
+            if isOn {
+                HStack(spacing: DesignTokens.Spacing.md) {
+                    Color.clear
+                        .frame(width: DesignTokens.Dimensions.settingsIconWidth)
+
+                    Spacer(minLength: DesignTokens.Spacing.sm)
+
+                    HStack(spacing: DesignTokens.Spacing.sm) {
+                        Text("Strength")
+                            .font(DesignTokens.Typography.caption)
+                            .foregroundStyle(DesignTokens.Colors.textTertiary)
+
+                        Slider(
+                            value: Binding(
+                                get: { Double(amount) },
+                                set: { amount = Float($0) }
+                            ),
+                            in: 0.0...1.0
+                        )
+                        .frame(width: DesignTokens.Dimensions.settingsSliderWidth)
+
+                        EditablePercentage(
+                            percentage: Binding(
+                                get: { Int(round(amount * 100)) },
+                                set: { amount = Float($0) / 100.0 }
+                            ),
+                            range: 0...100
+                        )
+                        .frame(width: DesignTokens.Dimensions.settingsPercentageWidth, alignment: .trailing)
+                    }
+                }
+            }
+        }
+        .hoverableRow()
+    }
+}
+
+#Preview("Loudness Compensation Row") {
+    VStack(spacing: DesignTokens.Spacing.sm) {
+        SettingsLoudnessCompensationRow(
+            isOn: .constant(true),
+            amount: .constant(0.65)
+        )
+    }
+    .padding()
+    .frame(width: 450)
+    .darkGlassBackground()
+    .environment(\.colorScheme, .dark)
+}

--- a/FineTune/Views/Settings/SettingsView.swift
+++ b/FineTune/Views/Settings/SettingsView.swift
@@ -14,12 +14,22 @@ struct SettingsView: View {
 
     @State private var showResetConfirmation = false
 
+    private var unifiedLoudnessToggleBinding: Binding<Bool> {
+        Binding(
+            get: { settings.loudnessCompensationEnabled && settings.loudnessEqualizationEnabled },
+            set: { isEnabled in
+                settings.setUnifiedLoudnessEnabled(isEnabled)
+            }
+        )
+    }
+
     var body: some View {
         // Scrollable settings content
         ScrollView {
             VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
                 generalSection
                 audioSection
+                loudnessSection
                 notificationsSection
                 dataSection
 
@@ -105,7 +115,16 @@ struct SettingsView: View {
                     deviceVolumeMonitor.setSystemFollowDefault()
                 }
             )
+
+            SettingsLoudnessCompensationRow(
+                isOn: unifiedLoudnessToggleBinding,
+                amount: $settings.loudnessCompensationAmount
+            )
         }
+    }
+
+    private var loudnessSection: some View {
+        EmptyView()
     }
 
     // MARK: - Notifications Section

--- a/FineTuneTests/ISO226ContoursTests.swift
+++ b/FineTuneTests/ISO226ContoursTests.swift
@@ -1,0 +1,276 @@
+// FineTuneTests/ISO226ContoursTests.swift
+
+import Foundation
+import Testing
+@testable import FineTune
+
+@Suite("ISO226Contours — ISO 226:2023")
+struct ISO226ContoursReferenceTests {
+
+    @Test("2023 Table 1 coefficients are loaded at critical frequencies")
+    func table1CriticalCoefficients() {
+        #expect(abs(ISO226Contours.referenceLoudnessExponent - 0.300) < 1e-12)
+
+        #expect(abs(ISO226Contours.loudnessPerceptionExponents[0] - 0.635) < 1e-12)
+        #expect(abs(ISO226Contours.transferMagnitudesDB[0] - (-31.5)) < 1e-12)
+        #expect(abs(ISO226Contours.hearingThresholdsDB[0] - 78.1) < 1e-12)
+
+        #expect(abs(ISO226Contours.loudnessPerceptionExponents[17] - 0.300) < 1e-12)
+        #expect(abs(ISO226Contours.transferMagnitudesDB[17] - 0.0) < 1e-12)
+        #expect(abs(ISO226Contours.hearingThresholdsDB[17] - 2.4) < 1e-12)
+
+        #expect(abs(ISO226Contours.loudnessPerceptionExponents[28] - 0.354) < 1e-12)
+        #expect(abs(ISO226Contours.transferMagnitudesDB[28] - (-3.5)) < 1e-12)
+        #expect(abs(ISO226Contours.hearingThresholdsDB[28] - 12.3) < 1e-12)
+    }
+
+    @Test("Normative contour values at 20 phon match ISO 226:2023 equation")
+    func contourReferenceValues20Phon() {
+        let contour = ISO226Contours.contourSPL(atPhon: 20.0)
+
+        expectClose(contour[0], 88.167, tolerance: 0.01)
+        expectClose(contour[5], 58.197, tolerance: 0.01)
+        expectClose(contour[17], 20.000, tolerance: 0.001)
+        expectClose(contour[23], 15.233, tolerance: 0.01)
+        expectClose(contour[28], 32.746, tolerance: 0.01)
+    }
+
+    @Test("Normative contour values at 40 phon match ISO 226:2023 equation")
+    func contourReferenceValues40Phon() {
+        let contour = ISO226Contours.contourSPL(atPhon: 40.0)
+
+        expectClose(contour[0], 99.456, tolerance: 0.01)
+        expectClose(contour[5], 72.849, tolerance: 0.01)
+        expectClose(contour[17], 40.000, tolerance: 0.001)
+        expectClose(contour[23], 36.712, tolerance: 0.01)
+        expectClose(contour[28], 51.253, tolerance: 0.01)
+    }
+
+    @Test("1 kHz reference contour remains identity in phon space",
+          arguments: [20.0, 40.0, 60.0, 80.0])
+    func oneKilohertzMatchesPhon(phon: Double) {
+        let contour = ISO226Contours.contourSPL(atPhon: phon)
+        expectClose(contour[17], phon, tolerance: 0.02)
+    }
+
+    @Test("System volume heuristic maps 100% volume to the reference phon")
+    func fullVolumeMapsToReferencePhon() {
+        expectClose(
+            ISO226Contours.estimatedPhon(fromSystemVolume: 1.0),
+            ISO226Contours.defaultReferencePhon,
+            tolerance: 0.001
+        )
+    }
+
+    @Test("20 Hz compensation reflects the 2023 low-frequency model and derived headroom")
+    func lowFrequencyTwentyHertzEdgeCase() {
+        let gains = ISO226Contours.compensationGains(atPhon: 20.0, referencePhon: 80.0)
+        let headroom = ISO226Contours.requiredHeadroomDB(forCompensationGains: gains)
+
+        expectClose(gains[0], 29.323, tolerance: 0.01)
+        expectClose(gains[17], 0.0, tolerance: 0.001)
+        expectClose(gains[23], -3.220, tolerance: 0.01)
+        expectClose(headroom, 29.323, tolerance: 0.01)
+    }
+
+    @Test("Compensation is normalized around 1 kHz instead of restoring overall loudness")
+    func normalizedCompensationAtMidVolume() {
+        let gains = ISO226Contours.compensationGains(atPhon: 52.5, referencePhon: 80.0)
+        let headroom = ISO226Contours.requiredHeadroomDB(forCompensationGains: gains)
+
+        expectClose(gains[0], 14.325, tolerance: 0.01)
+        expectClose(gains[5], 10.161, tolerance: 0.01)
+        expectClose(gains[17], 0.0, tolerance: 0.001)
+        expectClose(gains[23], -1.130, tolerance: 0.01)
+        expectClose(gains[28], 4.024, tolerance: 0.01)
+        expectClose(headroom, 14.325, tolerance: 0.01)
+    }
+
+    @Test("Reference phon contour produces flat compensation")
+    func referencePhonIsFlat() {
+        let gains = ISO226Contours.compensationGains(atPhon: 80.0)
+        #expect(gains.allSatisfy { abs($0) < 1e-9 })
+        #expect(abs(ISO226Contours.requiredHeadroomDB(forCompensationGains: gains)) < 1e-9)
+    }
+
+    @Test("Compensation amount scales the normalized contour strength")
+    func compensationAmountScalesTargetCurve() {
+        let full = ISO226Contours.compensationGains(atPhon: 20.0, amount: 1.0)
+        let half = ISO226Contours.compensationGains(atPhon: 20.0, amount: 0.5)
+        let flat = ISO226Contours.compensationGains(atPhon: 20.0, amount: 0.0)
+
+        expectClose(full[0], 29.323, tolerance: 0.01)
+        expectClose(half[0], 14.6615, tolerance: 0.01)
+        expectClose(half[23], -1.610, tolerance: 0.01)
+        #expect(flat.allSatisfy { abs($0) < 1e-9 })
+    }
+}
+
+@Suite("ISO226Contours — migration deltas")
+struct ISO226ContoursMigrationTests {
+
+    @Test("Migration preserves a documented delta against the legacy in-app table at key points")
+    func legacyDeltaSnapshots() {
+        let contour20 = ISO226Contours.contourSPL(atPhon: 20.0)
+        let contour40 = ISO226Contours.contourSPL(atPhon: 40.0)
+        let contour80 = ISO226Contours.contourSPL(atPhon: 80.0)
+
+        expectClose(contour20[0] - legacyContour20Phon[0], 13.867, tolerance: 0.01)
+        expectClose(contour20[17] - legacyContour20Phon[17], 16.800, tolerance: 0.01)
+        expectClose(contour40[5] - legacyContour40Phon[5], 25.849, tolerance: 0.01)
+        expectClose(contour80[23] - legacyContour80Phon[23], 74.953, tolerance: 0.01)
+        expectClose(contour80[28] - legacyContour80Phon[28], 80.603, tolerance: 0.01)
+    }
+
+    private let legacyContour20Phon: [Double] = [
+        74.3, 65.0, 56.3, 48.4, 41.7, 35.5, 29.8, 25.1, 20.7, 16.8,
+        13.8, 11.2, 9.0, 7.2, 6.0, 4.9, 4.0, 3.2, 2.4, 1.4,
+        1.0, 0.5, 0.1, 0.0, -0.5, -1.3, -3.0, -4.0, -2.0,
+    ]
+
+    private let legacyContour40Phon: [Double] = [
+        86.0, 77.5, 68.7, 60.7, 53.7, 47.0, 40.7, 35.0, 30.0, 25.3,
+        21.3, 17.8, 15.0, 12.5, 10.5, 8.9, 7.5, 6.3, 5.0, 3.5,
+        2.5, 1.5, 0.8, 0.5, 0.1, -0.4, -1.5, -2.5, 0.5,
+    ]
+
+    private let legacyContour80Phon: [Double] = [
+        99.5, 91.0, 82.5, 75.5, 69.5, 63.0, 57.0, 51.0, 45.5, 40.0,
+        35.0, 30.5, 27.0, 23.5, 20.5, 18.0, 15.5, 13.5, 11.5, 9.5,
+        7.5, 5.8, 4.3, 3.5, 3.0, 2.5, 1.5, 0.0, 5.0,
+    ]
+
+    private func expectClose(_ actual: Double, _ expected: Double, tolerance: Double) {
+        #expect(abs(actual - expected) <= tolerance, "Expected \(expected), got \(actual)")
+    }
+}
+
+@Suite("LoudnessCompensator — headroom fitting")
+struct LoudnessCompensatorHeadroomTests {
+
+    @Test("Derived loudness headroom covers the fitted cascade peak at 3% system volume")
+    func fittedCascadePeakIsCoveredAtThreePercentVolume() {
+        let sampleRate = 48_000.0
+        let phon = ISO226Contours.estimatedPhon(fromSystemVolume: 0.03)
+        let sectionGains = LoudnessCompensator.fittedSectionGains(forPhon: phon, sampleRate: sampleRate)
+        let headroomDB = LoudnessCompensator.requiredHeadroomDB(forBandGains: sectionGains)
+        let coefficients = LoudnessCompensator.coefficientsForBands(gains: sectionGains, sampleRate: sampleRate)
+
+        let peakDB = peakCascadeResponseDB(
+            coefficients: coefficients,
+            sectionCount: LoudnessCompensator.bandCount,
+            sampleRate: sampleRate
+        ) - headroomDB
+
+        #expect(peakDB <= 0.1, "Net cascade peak should be <= 0 dB after headroom, got \(peakDB) dB")
+    }
+
+    @Test("4-filter loudness fit tracks the target contour at 3% system volume")
+    func fittedCascadeTracksTargetAtThreePercentVolume() {
+        let sampleRate = 48_000.0
+        let phon = ISO226Contours.estimatedPhon(fromSystemVolume: 0.03)
+        let targetGains = ISO226Contours.compensationGains(atPhon: phon)
+        let fittedGains = LoudnessCompensator.fittedSectionGains(forPhon: phon, sampleRate: sampleRate)
+        let coefficients = LoudnessCompensator.coefficientsForBands(gains: fittedGains, sampleRate: sampleRate)
+
+        #expect(LoudnessCompensator.bandCount == 4)
+
+        var lowFrequencySquaredError = 0.0
+        var lowFrequencyCount = 0
+        var maxAbsError = 0.0
+
+        for index in 0..<96 {
+            let frequency = 20.0 * pow(20_000.0 / 20.0, Double(index) / 95.0)
+            let targetDB = ISO226Contours.interpolateCompensation(targetGains, atFrequency: frequency)
+            let realizedDB = cascadeResponseDB(
+                coefficients: coefficients,
+                sectionCount: LoudnessCompensator.bandCount,
+                sampleRate: sampleRate,
+                frequency: frequency
+            )
+            let responseError = realizedDB - targetDB
+            maxAbsError = max(maxAbsError, abs(responseError))
+
+            if frequency <= 150.0 {
+                lowFrequencySquaredError += responseError * responseError
+                lowFrequencyCount += 1
+            }
+        }
+
+        let lowFrequencyRMSE = sqrt(lowFrequencySquaredError / Double(lowFrequencyCount))
+        #expect(lowFrequencyRMSE <= 2.0, "Low-frequency RMSE should stay within 2 dB, got \(lowFrequencyRMSE) dB")
+        #expect(maxAbsError <= 3.0, "Max fitted-response error should stay within 3 dB, got \(maxAbsError) dB")
+    }
+
+    private func peakCascadeResponseDB(coefficients: [Double], sectionCount: Int, sampleRate: Double) -> Double {
+        var peakDB = -Double.infinity
+        for index in 0..<4096 {
+            let frequency = 20.0 * pow(20_000.0 / 20.0, Double(index) / 4095.0)
+            peakDB = max(
+                peakDB,
+                cascadeResponseDB(
+                    coefficients: coefficients,
+                    sectionCount: sectionCount,
+                    sampleRate: sampleRate,
+                    frequency: frequency
+                )
+            )
+        }
+        return peakDB
+    }
+
+    private func cascadeResponseDB(
+        coefficients: [Double],
+        sectionCount: Int,
+        sampleRate: Double,
+        frequency: Double
+    ) -> Double {
+        let normalizedFrequency = 2.0 * Double.pi * frequency / sampleRate
+        let magnitude = stride(from: 0, to: sectionCount * 5, by: 5).reduce(1.0) { partial, offset in
+            partial * magnitudeResponse(
+                coefficients: Array(coefficients[offset..<(offset + 5)]),
+                atNormalizedFrequency: normalizedFrequency
+            )
+        }
+        return 20.0 * log10(magnitude)
+    }
+
+    private func magnitudeResponse(coefficients: [Double], atNormalizedFrequency omega: Double) -> Double {
+        let cosW = cos(omega)
+        let sinW = sin(omega)
+        let cos2W = cos(2.0 * omega)
+        let sin2W = sin(2.0 * omega)
+
+        let numeratorReal = coefficients[0] + coefficients[1] * cosW + coefficients[2] * cos2W
+        let numeratorImag = -(coefficients[1] * sinW + coefficients[2] * sin2W)
+        let denominatorReal = 1.0 + coefficients[3] * cosW + coefficients[4] * cos2W
+        let denominatorImag = -(coefficients[3] * sinW + coefficients[4] * sin2W)
+
+        return sqrt(
+            (numeratorReal * numeratorReal + numeratorImag * numeratorImag) /
+            (denominatorReal * denominatorReal + denominatorImag * denominatorImag)
+        )
+    }
+}
+
+@Suite("LoudnessCompensator — enable state")
+struct LoudnessCompensatorEnableStateTests {
+
+    @Test("Re-enabling loudness at the same system volume immediately restores the effect")
+    func sameVolumeReEnableRestoresProcessing() {
+        let processor = LoudnessCompensator(sampleRate: 48_000)
+
+        processor.updateForVolume(0.25)
+        #expect(processor.isEnabled, "Processor should enable after an initial non-reference volume update")
+
+        processor.setEnabled(false)
+        #expect(!processor.isEnabled, "Test setup should disable the processor before re-enabling")
+
+        processor.updateForVolume(0.25)
+        #expect(processor.isEnabled, "Processor should re-enable immediately even if volume did not change")
+    }
+}
+
+private func expectClose(_ actual: Double, _ expected: Double, tolerance: Double) {
+    #expect(abs(actual - expected) <= tolerance, "Expected \(expected), got \(actual)")
+}

--- a/FineTuneTests/LoudnessEqualizerTests.swift
+++ b/FineTuneTests/LoudnessEqualizerTests.swift
@@ -1,0 +1,339 @@
+// FineTuneTests/LoudnessEqualizerTests.swift
+// Unit tests for the LoudnessEqualizer feature.
+
+import Testing
+import Foundation
+@testable import FineTune
+
+@Suite("LoudnessEqualizer")
+struct LoudnessEqualizerTests {
+
+    // MARK: - LoudnessEqualizerSettings
+
+    @Test("Settings default to approved MVP values")
+    func settingsDefaults() {
+        let s = LoudnessEqualizerSettings()
+        #expect(s.targetLoudnessDb == -12)
+        #expect(s.maxBoostDb == 15)
+        #expect(s.maxCutDb == 4)
+        #expect(s.compressionThresholdOffsetDb == 6)
+        #expect(s.compressionRatio == 1.6)
+        #expect(s.compressionKneeDb == 8)
+        #expect(s.analysisWindowMs == 30)
+        #expect(s.analysisHopMs == 15)
+        #expect(s.detectorAttackMs == 25)
+        #expect(s.detectorReleaseMs == 400)
+        #expect(s.gainAttackMs == 180)
+        #expect(s.gainReleaseMs == 5000)
+        #expect(s.noiseFloorThresholdDb == -48)
+        #expect(s.lowLevelMaxBoostDb == 1.5)
+        #expect(s.limiterCeilingDb == -1)
+        #expect(s.enabled == false)
+    }
+
+    // MARK: - LoudnessEqualizerMath
+
+    @Test("dB and linear conversions round-trip within tolerance")
+    func dbLinearRoundTrip() {
+        let testValues: [Float] = [-60, -20, -6, 0, 6, 20]
+        for db in testValues {
+            let linear = LoudnessEqualizerMath.dbToLinear(db)
+            let roundTripped = LoudnessEqualizerMath.linearToDb(linear)
+            #expect(abs(roundTripped - db) < 0.001,
+                    "Round-trip failed for \(db) dB: got \(roundTripped)")
+        }
+        // 0 dB should map to linear 1.0
+        #expect(abs(LoudnessEqualizerMath.dbToLinear(0) - 1.0) < 0.0001)
+        // -∞ dB edge: linear 0 should map to a very negative dB value
+        let veryNegative = LoudnessEqualizerMath.linearToDb(0)
+        #expect(veryNegative < -100)
+    }
+
+    @Test("Shorter time constant produces faster smoothing coefficient")
+    func smoothingCoefficientOrder() {
+        let stepMs: Float = 1.0
+        let fast = LoudnessEqualizerMath.timeConstantCoefficient(timeMs: 10, stepMs: stepMs)
+        let slow = LoudnessEqualizerMath.timeConstantCoefficient(timeMs: 100, stepMs: stepMs)
+        // A shorter time constant means larger coefficient (reaches target faster per step)
+        #expect(fast > slow,
+                "10 ms coefficient (\(fast)) should be larger than 100 ms coefficient (\(slow))")
+        // Coefficients must be in (0, 1) exclusive
+        #expect(fast > 0 && fast < 1)
+        #expect(slow > 0 && slow < 1)
+    }
+
+    // MARK: - KWeightingFilter
+
+    @Test("K-weighting reset reproduces identical output for same input")
+    func kWeightingResetDeterminism() {
+        let filter = KWeightingFilter(sampleRate: 48000)
+        let impulse: Float = 1.0
+        // Run the filter once and capture output
+        let firstPass = filter.processSample(impulse)
+        for _ in 0..<99 {
+            _ = filter.processSample(0)
+        }
+        // Reset and replay — output must be identical
+        filter.reset()
+        let secondPass = filter.processSample(impulse)
+        #expect(firstPass == secondPass,
+                "After reset, first output (\(secondPass)) must equal original first output (\(firstPass))")
+    }
+
+    // MARK: - LoudnessDetector
+
+    @Test("Detector attack responds faster than release")
+    func detectorAttackFasterThanRelease() {
+        var settings = LoudnessEqualizerSettings()
+        settings.detectorAttackMs = 15
+        settings.detectorReleaseMs = 120
+        let sampleRate: Float = 48000
+        let detector = LoudnessDetector(settings: settings, sampleRate: sampleRate)
+
+        // Start from a known level
+        let startDb: Float = -30
+        // Simulate attack: jump up by 20 dB
+        let highDb: Float = -10
+        // Simulate release: drop back down
+        let lowDb: Float = -30
+
+        // Drive envelope up for a few steps
+        var attackLevel: Float = startDb
+        for _ in 0..<5 {
+            attackLevel = detector.updateEnvelope(with: highDb)
+        }
+
+        // Reset and drive envelope down for same number of steps from high
+        detector.reset()
+        // Seed at high level first
+        for _ in 0..<20 {
+            _ = detector.updateEnvelope(with: highDb)
+        }
+        var releaseLevel: Float = highDb
+        for _ in 0..<5 {
+            releaseLevel = detector.updateEnvelope(with: lowDb)
+        }
+
+        // After 5 attack steps from -30 toward -10, level should be closer to -10
+        // After 5 release steps from -10 toward -30, level should still be closer to -10
+        // So the attack gain (distance covered) should be larger than the release gain
+        let attackGain = attackLevel - startDb   // positive: moved up
+        let releaseGain = highDb - releaseLevel  // positive: moved down
+
+        #expect(attackGain > releaseGain,
+                "Attack moved \(attackGain) dB in 5 steps; release moved \(releaseGain) dB — attack should be faster")
+    }
+
+    // MARK: - GainComputer
+
+    @Test("Gain computer boosts quiet material and softly cuts louder material")
+    func gainComputerClamps() {
+        var settings = LoudnessEqualizerSettings()
+        settings.targetLoudnessDb = -12
+        settings.maxBoostDb = 4
+        settings.maxCutDb = 6
+        settings.compressionThresholdOffsetDb = 4
+        settings.compressionRatio = 1.5
+        settings.compressionKneeDb = 6
+        settings.noiseFloorThresholdDb = -80 // disable noise floor for this test
+        let computer = GainComputer(settings: settings)
+
+        let quietSignal = computer.desiredGainDb(forLevelDb: -18)
+        #expect(quietSignal == settings.maxBoostDb, "Quiet signals should still boost toward target")
+
+        let withinKnee = computer.desiredGainDb(forLevelDb: -10)
+        #expect(withinKnee < 0, "Signals inside the soft knee should get a small cut")
+        #expect(withinKnee > -1.5, "Soft-knee cut should stay gentle near the threshold")
+
+        let loudSignal = computer.desiredGainDb(forLevelDb: 12)
+        #expect(loudSignal == -settings.maxCutDb, "Very loud signals should clamp to maxCutDb")
+    }
+
+    @Test("Gain computer limits boost below noise floor threshold")
+    func gainComputerNoiseFloorProtection() {
+        var settings = LoudnessEqualizerSettings()
+        settings.targetLoudnessDb = -20
+        settings.maxBoostDb = 10
+        settings.noiseFloorThresholdDb = -55
+        settings.lowLevelMaxBoostDb = 4
+        let computer = GainComputer(settings: settings)
+
+        // Signal well below the noise floor threshold should have boost limited to lowLevelMaxBoostDb
+        let gainAtNoise = computer.desiredGainDb(forLevelDb: -70)
+        #expect(gainAtNoise <= settings.lowLevelMaxBoostDb, "Boost near noise floor should be capped at lowLevelMaxBoostDb")
+    }
+
+    // MARK: - GainSmoother
+
+    @Test("Gain smoother reduces gain faster than it recovers")
+    func gainSmootherAsymmetry() {
+        var settings = LoudnessEqualizerSettings()
+        settings.gainAttackMs = 30    // fast reduction (attack toward lower gain)
+        settings.gainReleaseMs = 700  // slow recovery (release toward higher gain)
+        let smoother = GainSmoother(settings: settings, sampleRate: 48000)
+
+        // Seed smoother at 0 dB
+        smoother.reset(initialGainDb: 0)
+
+        // Attack: target is -10 dB (reduction)
+        var attackLevel: Float = 0
+        for _ in 0..<10 {
+            attackLevel = smoother.process(targetGainDb: -10)
+        }
+
+        // Reset and seed at -10 dB, then release toward 0 dB
+        smoother.reset(initialGainDb: -10)
+        var releaseLevel: Float = -10
+        for _ in 0..<10 {
+            releaseLevel = smoother.process(targetGainDb: 0)
+        }
+
+        // In 10 steps the gain reduction (attack) should cover more distance than recovery (release)
+        let attackDistance = abs(attackLevel - 0)      // how far from 0 dB after attack steps
+        let releaseDistance = abs(releaseLevel - (-10)) // how far from -10 dB after release steps
+
+        #expect(releaseDistance < attackDistance,
+                "Gain smoother should recover (\(releaseDistance) dB) slower than it reduces (\(attackDistance) dB)")
+    }
+
+    // MARK: - LoudnessEqualizer
+
+    @Test("Shared gain preserves left-right ratio for interleaved stereo buffers")
+    func loudnessEqualizerPreservesStereoImage() {
+        var settings = LoudnessEqualizerSettings()
+        settings.enabled = true
+        let sampleRate: Float = 48000
+        let frameCount = 512
+        let channelCount = 2
+
+        let eq = LoudnessEqualizer(settings: settings, sampleRate: sampleRate, channelCount: channelCount)
+
+        // Input is interleaved production-style stereo: L0,R0,L1,R1,...
+        var input = [Float](repeating: 0, count: frameCount * channelCount)
+        for frame in 0..<frameCount {
+            let base = frame * channelCount
+            input[base] = 0.5
+            input[base + 1] = 0.25
+        }
+
+        var output = [Float](repeating: 0, count: frameCount * channelCount)
+
+        input.withUnsafeMutableBufferPointer { inPtr in
+            output.withUnsafeMutableBufferPointer { outPtr in
+                eq.process(
+                    input: inPtr.baseAddress!,
+                    output: outPtr.baseAddress!,
+                    frameCount: frameCount,
+                    channelCount: channelCount
+                )
+            }
+        }
+
+        // Extract output channels (interleaved: L0,R0,L1,R1,…)
+        let outLeft  = stride(from: 0, to: frameCount * channelCount, by: channelCount).map { output[$0] }
+        let outRight = stride(from: 1, to: frameCount * channelCount, by: channelCount).map { output[$0] }
+
+        // Verify non-zero output (gain was applied)
+        let sumLeft  = outLeft.map(abs).reduce(0, +)
+        let sumRight = outRight.map(abs).reduce(0, +)
+        #expect(sumLeft > 0,  "Left channel output should be non-zero")
+        #expect(sumRight > 0, "Right channel output should be non-zero")
+
+        // Verify L/R ratio is preserved within 1% tolerance
+        // Both channels receive the same gain factor, so ratio should stay 2:1
+        let ratio = sumLeft / sumRight
+        #expect(abs(ratio - 2.0) < 0.02,
+                "Left/right ratio should remain 2:1 after loudness processing; got \(ratio)")
+    }
+
+    @Test("Disabled equalizer is unity passthrough for interleaved stereo buffers")
+    func disabledEqualizerPassesThroughUnchanged() {
+        let settings = LoudnessEqualizerSettings()
+        let sampleRate: Float = 48000
+        let frameCount = 256
+        let channelCount = 2
+
+        let eq = LoudnessEqualizer(settings: settings, sampleRate: sampleRate, channelCount: channelCount)
+
+        var input = [Float](repeating: 0, count: frameCount * channelCount)
+        for frame in 0..<frameCount {
+            let base = frame * channelCount
+            input[base] = Float(frame) / Float(frameCount)
+            input[base + 1] = -0.5 * Float(frame) / Float(frameCount)
+        }
+        var output = [Float](repeating: 0, count: frameCount * channelCount)
+
+        input.withUnsafeMutableBufferPointer { inPtr in
+            output.withUnsafeMutableBufferPointer { outPtr in
+                eq.process(
+                    input: inPtr.baseAddress!,
+                    output: outPtr.baseAddress!,
+                    frameCount: frameCount,
+                    channelCount: channelCount
+                )
+            }
+        }
+
+        for index in 0..<input.count {
+            #expect(abs(output[index] - input[index]) < 1e-7,
+                    "Disabled equalizer should pass through sample \(index) unchanged; expected \(input[index]), got \(output[index])")
+        }
+    }
+
+    @Test("Disabling after active gain riding restores immediate unity passthrough")
+    func disablingAfterProcessingClearsResidualGain() {
+        var settings = LoudnessEqualizerSettings()
+        settings.enabled = true
+
+        let sampleRate: Float = 48000
+        let frameCount = 2048
+        let channelCount = 2
+        let eq = LoudnessEqualizer(settings: settings, sampleRate: sampleRate, channelCount: channelCount)
+
+        var loudInput = [Float](repeating: 0, count: frameCount * channelCount)
+        for frame in 0..<frameCount {
+            let base = frame * channelCount
+            loudInput[base] = 0.95
+            loudInput[base + 1] = 0.95
+        }
+        var loudOutput = [Float](repeating: 0, count: frameCount * channelCount)
+
+        loudInput.withUnsafeMutableBufferPointer { inPtr in
+            loudOutput.withUnsafeMutableBufferPointer { outPtr in
+                eq.process(
+                    input: inPtr.baseAddress!,
+                    output: outPtr.baseAddress!,
+                    frameCount: frameCount,
+                    channelCount: channelCount
+                )
+            }
+        }
+
+        settings.enabled = false
+        eq.updateSettings(settings)
+
+        var quietInput = [Float](repeating: 0, count: frameCount * channelCount)
+        for frame in 0..<frameCount {
+            let base = frame * channelCount
+            quietInput[base] = 0.2
+            quietInput[base + 1] = -0.1
+        }
+        var quietOutput = [Float](repeating: 0, count: frameCount * channelCount)
+
+        quietInput.withUnsafeMutableBufferPointer { inPtr in
+            quietOutput.withUnsafeMutableBufferPointer { outPtr in
+                eq.process(
+                    input: inPtr.baseAddress!,
+                    output: outPtr.baseAddress!,
+                    frameCount: frameCount,
+                    channelCount: channelCount
+                )
+            }
+        }
+
+        for index in 0..<quietInput.count {
+            #expect(abs(quietOutput[index] - quietInput[index]) < 1e-6,
+                    "Disabling should clear residual gain immediately at sample \(index); expected \(quietInput[index]), got \(quietOutput[index])")
+        }
+    }
+}

--- a/FineTuneTests/ProcessingPipelineTests.swift
+++ b/FineTuneTests/ProcessingPipelineTests.swift
@@ -14,6 +14,7 @@
 import AudioToolbox
 import Accelerate
 import Testing
+import Foundation
 @testable import FineTune
 
 // MARK: - Test Helpers
@@ -102,7 +103,9 @@ private func processWithDefaults(
     preferredStereoRight: Int = 1,
     currentVol: inout Float,
     eqProc: EQProcessor? = nil,
-    autoEQProc: AutoEQProcessor? = nil
+    autoEQProc: AutoEQProcessor? = nil,
+    loudnessEqualizerProc: LoudnessEqualizer? = nil,
+    loudnessCompensatorProc: LoudnessCompensator? = nil
 ) {
     ProcessTapController.processMappedBuffers(
         inputBuffers: input.bufferList,
@@ -114,8 +117,19 @@ private func processWithDefaults(
         preferredStereoRight: preferredStereoRight,
         currentVol: &currentVol,
         eqProc: eqProc,
-        autoEQProc: autoEQProc
+        autoEQProc: autoEQProc,
+        loudnessEqualizerProc: loudnessEqualizerProc,
+        loudnessCompensatorProc: loudnessCompensatorProc
     )
+}
+
+private func repositoryRootURL() -> URL {
+    URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent()
+}
+
+private func loadRepositorySource(_ relativePath: String) throws -> String {
+    let url = repositoryRootURL().appendingPathComponent(relativePath)
+    return try String(contentsOf: url, encoding: .utf8)
 }
 
 // MARK: - Buffer Mapping Tests

--- a/FineTuneTests/SettingsManagerTests.swift
+++ b/FineTuneTests/SettingsManagerTests.swift
@@ -218,6 +218,73 @@ struct AppSettingsDefaultTests {
         #expect(settings.lockInputDevice == true)
         #expect(settings.showDeviceDisconnectAlerts == true)
     }
+
+    @Test("loudnessEqualizationEnabled defaults to false")
+    func loudnessEqualizationEnabledDefault() {
+        let settings = AppSettings()
+        #expect(settings.loudnessEqualizationEnabled == false)
+    }
+
+    @Test("loudnessCompensationAmount defaults to 1.0")
+    func loudnessCompensationAmountDefault() {
+        let settings = AppSettings()
+        #expect(settings.loudnessCompensationAmount == 1.0)
+    }
+
+    @Test("loudnessEqualizationEnabled round-trips through JSON as true")
+    func loudnessEqualizationEnabledRoundTrip() throws {
+        var settings = AppSettings()
+        settings.loudnessEqualizationEnabled = true
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+        #expect(decoded.loudnessEqualizationEnabled == true)
+    }
+
+    @Test("loudnessCompensationAmount round-trips through JSON")
+    func loudnessCompensationAmountRoundTrip() throws {
+        var settings = AppSettings()
+        settings.loudnessCompensationAmount = 0.35
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+        #expect(decoded.loudnessCompensationAmount == 0.35)
+    }
+
+    @Test("Unified loudness toggle updates compensation and equalization together")
+    func unifiedLoudnessToggleSetsBothFlags() {
+        var settings = AppSettings()
+
+        settings.setUnifiedLoudnessEnabled(true)
+        #expect(settings.loudnessCompensationEnabled == true)
+        #expect(settings.loudnessEqualizationEnabled == true)
+
+        settings.setUnifiedLoudnessEnabled(false)
+        #expect(settings.loudnessCompensationEnabled == false)
+        #expect(settings.loudnessEqualizationEnabled == false)
+    }
+
+    @Test("loudnessEqualizationEnabled persists via SettingsManager")
+    @MainActor
+    func loudnessEqualizationEnabledPersistence() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        let manager = SettingsManager(directory: tempDir)
+        var newSettings = manager.appSettings
+        newSettings.loudnessEqualizationEnabled = true
+        manager.updateAppSettings(newSettings)
+        #expect(manager.appSettings.loudnessEqualizationEnabled == true)
+    }
+
+    @Test("loudnessCompensationAmount persists via SettingsManager")
+    @MainActor
+    func loudnessCompensationAmountPersistence() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        let manager = SettingsManager(directory: tempDir)
+        var newSettings = manager.appSettings
+        newSettings.loudnessCompensationAmount = 0.6
+        manager.updateAppSettings(newSettings)
+        #expect(manager.appSettings.loudnessCompensationAmount == 0.6)
+    }
 }
 
 // MARK: - MenuBarIconStyle


### PR DESCRIPTION
## What

Adds dynamic **loudness compensation** using the latest ISO 226:2023 equal-loudness contours (updated Fletcher-Munson curves).  
This maintains consistent tonal balance and perceived frequency response at all volume levels — especially important at low listening volumes where bass and high frequencies usually get lost.

## Key Changes

- **Loudness Compensator** — core component that calculates and applies ISO 226:2023 compliant frequency-dependent gain curves in real-time
- **Real-time Loudness Equalizer** — dynamic adjustment with K-weighting filter for perceptual loudness measurement
- **Gain Computer** — accurate ISO 226:2023 contour math with smooth interpolation
- **Gain Smoother** — lock-free, zero-allocation implementation for audio thread safety
- Full integration into the existing audio processing pipeline
- New settings UI row with enable/disable toggle + configuration options
- New unit tests covering ISO 226 compliance, mathematical correctness, and full processing chain integration

This addresses the common issue where audio sounds thin and lacking bass at lower volumes.

---

**Note**: This is my first contribution to the project. I have reviewed the [Contributing Guidelines](https://github.com/ronitsingh10/FineTune/blob/main/CONTRIBUTING.md) and ensured full compliance with real-time audio requirements.

Closes #199 

<img width="569" height="193" alt="image" src="https://github.com/user-attachments/assets/86814999-1330-4dcb-9a6b-ebfa93833cf7" />
