### PR TITLE
feat(settings): auto-switch to newly connected outputs

### DIFF
--- a/FineTune/Audio/Engine/AudioEngine.swift
+++ b/FineTune/Audio/Engine/AudioEngine.swift
@@ -58,6 +58,11 @@ final class AudioEngine {
         case pendingAutoSwitch(connectedDeviceUID: String, timeoutTask: Task<Void, Never>)
     }
 
+    enum PendingOutputAutoSwitchDecision: Equatable {
+        case acceptConnectedDevice
+        case restoreConfirmedDefault
+    }
+
     private var outputPriorityState: PriorityState = .stable
     private var inputPriorityState: PriorityState = .stable
 
@@ -178,6 +183,38 @@ final class AudioEngine {
         return connectedDevices.first {
             $0.uid != excluding && aliveCheck($0.id)
         }
+    }
+
+    static func shouldSwitchToConnectedOutputDevice(
+        connectedDeviceUID: String,
+        currentDefaultUID: String?,
+        highestPriorityUID: String?,
+        autoSwitchToConnectedOutputDevice: Bool
+    ) -> Bool {
+        guard connectedDeviceUID != currentDefaultUID else { return false }
+        if autoSwitchToConnectedOutputDevice {
+            return true
+        }
+        return connectedDeviceUID == highestPriorityUID
+    }
+
+    static func resolvePendingAutoSwitchDecision(
+        newDefaultUID: String,
+        pendingConnectedDeviceUID: String,
+        autoSwitchToConnectedOutputDevice: Bool,
+        lastAutoSwitchOverrideTime: Date?,
+        now: Date = Date()
+    ) -> PendingOutputAutoSwitchDecision {
+        if autoSwitchToConnectedOutputDevice {
+            return .acceptConnectedDevice
+        }
+
+        if let lastOverride = lastAutoSwitchOverrideTime,
+           now.timeIntervalSince(lastOverride) > 1.0 {
+            return .acceptConnectedDevice
+        }
+
+        return .restoreConfirmedDefault
     }
 
 
@@ -1243,6 +1280,24 @@ final class AudioEngine {
         }
     }
 
+    private func confirmOutputDefault(_ uid: String) {
+        lastConfirmedDefaultUID = uid
+        routeFollowsDefaultApps(to: uid)
+    }
+
+    @discardableResult
+    private func applyOutputDefault(to target: AudioDevice) -> Bool {
+        let currentDefault = deviceVolumeMonitor.defaultDeviceUID
+        if target.uid != currentDefault {
+            guard deviceVolumeMonitor.setDefaultDevice(target.id) else { return false }
+            outputEchoTracker.increment(target.uid)
+            logger.info("System default → \(target.name)")
+        }
+
+        confirmOutputDefault(target.uid)
+        return true
+    }
+
     /// Ensures system default matches highest-priority alive connected device.
     /// Routes followsDefault apps and switches their taps if default changes.
     /// Returns the resolved target UID.
@@ -1255,17 +1310,7 @@ final class AudioEngine {
             isAlive: isAliveCheck
         ) else { return nil }
 
-        let currentDefault = deviceVolumeMonitor.defaultDeviceUID
-        if target.uid != currentDefault {
-            if deviceVolumeMonitor.setDefaultDevice(target.id) {
-                outputEchoTracker.increment(target.uid)
-                logger.info("System default → \(target.name)")
-            }
-        }
-
-        lastConfirmedDefaultUID = target.uid
-        routeFollowsDefaultApps(to: target.uid)
-        return target.uid
+        return applyOutputDefault(to: target) ? target.uid : nil
     }
 
     /// Ensures system default input matches highest-priority alive connected input device.
@@ -1521,9 +1566,26 @@ final class AudioEngine {
             installAliveWatcher(deviceID: device.id, uid: deviceUID, name: deviceName)
         }
 
-        if isNewDeviceHigherPriority, deviceUID != currentDefault {
-            // A higher-priority device reconnected — switch to it
-            reEvaluateOutputDefault()
+        let autoSwitchConnectedOutput = settingsManager.appSettings.autoSwitchToConnectedOutputDevice
+        let shouldSwitchToConnectedOutput = Self.shouldSwitchToConnectedOutputDevice(
+            connectedDeviceUID: deviceUID,
+            currentDefaultUID: currentDefault,
+            highestPriorityUID: Self.resolveHighestPriority(
+                priorityOrder: settingsManager.devicePriorityOrder,
+                connectedDevices: outputDevices,
+                isAlive: isAliveCheck
+            )?.uid,
+            autoSwitchToConnectedOutputDevice: autoSwitchConnectedOutput
+        )
+        let shouldAcceptConnectedOutput = autoSwitchConnectedOutput || isNewDeviceHigherPriority
+
+        if shouldAcceptConnectedOutput,
+           let device = deviceMonitor.device(for: deviceUID),
+           isAliveCheck(device.id) {
+            _ = applyOutputDefault(to: device)
+        } else if shouldSwitchToConnectedOutput {
+            // Preserve the explicit intent in logs if the device became unavailable after resolution.
+            logger.debug("Connected output \(deviceName) matched auto-switch policy but is not ready yet")
         } else if !isNewDeviceHigherPriority, currentDefault == deviceUID {
             // macOS already auto-switched to the lower-priority device — restore
             // what the user was on (not highest priority — they may have chosen a mid-priority device)
@@ -1673,42 +1735,43 @@ final class AudioEngine {
             }
 
             if newDefaultUID == pendingUID {
-                // Settling heuristic: if >1s since last override, BT auto-switches have
-                // settled. This is likely the user changing via System Settings — accept it.
-                // BT auto-switches happen within ms; user actions take >1s.
-                if let lastOverride = lastAutoSwitchOverrideTime,
-                   Date().timeIntervalSince(lastOverride) > 1.0 {
+                switch Self.resolvePendingAutoSwitchDecision(
+                    newDefaultUID: newDefaultUID,
+                    pendingConnectedDeviceUID: pendingUID,
+                    autoSwitchToConnectedOutputDevice: settingsManager.appSettings.autoSwitchToConnectedOutputDevice,
+                    lastAutoSwitchOverrideTime: lastAutoSwitchOverrideTime
+                ) {
+                case .acceptConnectedDevice:
                     timeoutTask.cancel()
                     outputPriorityState = .stable
-                    lastConfirmedDefaultUID = newDefaultUID
+                    confirmOutputDefault(newDefaultUID)
                     lastAutoSwitchOverrideTime = nil
-                    routeFollowsDefaultApps(to: newDefaultUID)
                     let deviceName = deviceMonitor.device(for: newDefaultUID)?.name ?? newDefaultUID
-                    logger.info("Accepted user change to \(deviceName) (settled >1s)")
+                    logger.info("Accepted connected output change to \(deviceName)")
+                    return
+                case .restoreConfirmedDefault:
+                    // Case 1: macOS auto-switched to the newly connected device — restore what
+                    // the user was on. Re-enter PENDING_AUTOSWITCH for further auto-switches.
+                    timeoutTask.cancel()
+                    restoreConfirmedDefault()
+                    lastAutoSwitchOverrideTime = Date()
+                    let transport = deviceMonitor.device(for: pendingUID)?.id.readTransportType()
+                    let timeout = (transport == .bluetooth || transport == .bluetoothLE)
+                        ? btAutoSwitchGracePeriod
+                        : autoSwitchGracePeriod
+                    let newTimeoutTask = Task { @MainActor [weak self] in
+                        try? await Task.sleep(for: .seconds(timeout))
+                        guard let self, !Task.isCancelled else { return }
+                        self.outputPriorityState = .stable
+                        self.lastAutoSwitchOverrideTime = nil
+                        self.logger.debug("Auto-switch grace period expired after override")
+                    }
+                    outputPriorityState = .pendingAutoSwitch(
+                        connectedDeviceUID: pendingUID,
+                        timeoutTask: newTimeoutTask
+                    )
                     return
                 }
-
-                // Case 1: macOS auto-switched to the newly connected device — restore what
-                // the user was on. Re-enter PENDING_AUTOSWITCH for further auto-switches.
-                timeoutTask.cancel()
-                restoreConfirmedDefault()
-                lastAutoSwitchOverrideTime = Date()
-                let transport = deviceMonitor.device(for: pendingUID)?.id.readTransportType()
-                let timeout = (transport == .bluetooth || transport == .bluetoothLE)
-                    ? btAutoSwitchGracePeriod
-                    : autoSwitchGracePeriod
-                let newTimeoutTask = Task { @MainActor [weak self] in
-                    try? await Task.sleep(for: .seconds(timeout))
-                    guard let self, !Task.isCancelled else { return }
-                    self.outputPriorityState = .stable
-                    self.lastAutoSwitchOverrideTime = nil
-                    self.logger.debug("Auto-switch grace period expired after override")
-                }
-                outputPriorityState = .pendingAutoSwitch(
-                    connectedDeviceUID: pendingUID,
-                    timeoutTask: newTimeoutTask
-                )
-                return
             }
 
             // Case 3: Genuine user intent (different device, not our echo) — respect it.

--- a/FineTune/Settings/SettingsManager.swift
+++ b/FineTune/Settings/SettingsManager.swift
@@ -54,6 +54,7 @@ struct AppSettings: Codable, Equatable {
 
     // Audio
     var defaultNewAppVolume: Float = 1.0      // 100% (unity gain)
+    var autoSwitchToConnectedOutputDevice: Bool = false  // Prefer newly connected outputs over current default
 
     // Input Device Lock
     var lockInputDevice: Bool = true          // Prevent auto-switching input device
@@ -80,6 +81,7 @@ struct AppSettings: Codable, Equatable {
         launchAtLogin = try c.decodeIfPresent(Bool.self, forKey: .launchAtLogin) ?? false
         menuBarIconStyle = try c.decodeIfPresent(MenuBarIconStyle.self, forKey: .menuBarIconStyle) ?? .default
         defaultNewAppVolume = try c.decodeIfPresent(Float.self, forKey: .defaultNewAppVolume) ?? 1.0
+        autoSwitchToConnectedOutputDevice = try c.decodeIfPresent(Bool.self, forKey: .autoSwitchToConnectedOutputDevice) ?? false
         lockInputDevice = try c.decodeIfPresent(Bool.self, forKey: .lockInputDevice) ?? true
         softwareDeviceVolumeEnabled = try c.decodeIfPresent(Bool.self, forKey: .softwareDeviceVolumeEnabled) ?? false
         showDeviceDisconnectAlerts = try c.decodeIfPresent(Bool.self, forKey: .showDeviceDisconnectAlerts) ?? true

--- a/FineTune/Views/Settings/SettingsView.swift
+++ b/FineTune/Views/Settings/SettingsView.swift
@@ -89,6 +89,13 @@ struct SettingsView: View {
             )
 
             SettingsToggleRow(
+                icon: "arrow.trianglehead.2.clockwise.rotate.90",
+                title: "Auto-Switch New Output",
+                description: "Automatically use newly connected output devices",
+                isOn: $settings.autoSwitchToConnectedOutputDevice
+            )
+
+            SettingsToggleRow(
                 icon: "speaker.badge.exclamationmark",
                 title: "Software Volume for Unsupported Devices",
                 description: "Add volume sliders for outputs without native controls (e.g. HDMI TVs)",

--- a/FineTuneTests/OutputDeviceAutoSwitchTests.swift
+++ b/FineTuneTests/OutputDeviceAutoSwitchTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import FineTune
+
+@Suite("Output auto-switch behavior")
+@MainActor
+struct OutputDeviceAutoSwitchTests {
+
+    @Test("Lower-priority connected output does not auto-switch when the setting is disabled")
+    func lowerPriorityDeviceRespectsPriorityWhenAutoSwitchDisabled() {
+        let shouldSwitch = AudioEngine.shouldSwitchToConnectedOutputDevice(
+            connectedDeviceUID: "headphones",
+            currentDefaultUID: "built-in",
+            highestPriorityUID: "built-in",
+            autoSwitchToConnectedOutputDevice: false
+        )
+
+        #expect(shouldSwitch == false)
+    }
+
+    @Test("Connected output auto-switches when the setting is enabled")
+    func connectedDeviceAutoSwitchesWhenSettingEnabled() {
+        let shouldSwitch = AudioEngine.shouldSwitchToConnectedOutputDevice(
+            connectedDeviceUID: "headphones",
+            currentDefaultUID: "built-in",
+            highestPriorityUID: "built-in",
+            autoSwitchToConnectedOutputDevice: true
+        )
+
+        #expect(shouldSwitch == true)
+    }
+
+    @Test("Highest-priority connected output still auto-switches when the setting is disabled")
+    func highestPriorityDeviceStillSwitchesWhenAutoSwitchDisabled() {
+        let shouldSwitch = AudioEngine.shouldSwitchToConnectedOutputDevice(
+            connectedDeviceUID: "headphones",
+            currentDefaultUID: "built-in",
+            highestPriorityUID: "headphones",
+            autoSwitchToConnectedOutputDevice: false
+        )
+
+        #expect(shouldSwitch == true)
+    }
+
+    @Test("Pending macOS auto-switch is accepted when connected-output auto-switch is enabled")
+    func pendingAutoSwitchAcceptsConnectedDeviceWhenSettingEnabled() {
+        let decision = AudioEngine.resolvePendingAutoSwitchDecision(
+            newDefaultUID: "headphones",
+            pendingConnectedDeviceUID: "headphones",
+            autoSwitchToConnectedOutputDevice: true,
+            lastAutoSwitchOverrideTime: nil,
+            now: Date(timeIntervalSince1970: 100)
+        )
+
+        #expect(decision == .acceptConnectedDevice)
+    }
+
+    @Test("Pending macOS auto-switch restores prior default when the setting is disabled")
+    func pendingAutoSwitchRestoresPreviousDefaultWhenSettingDisabled() {
+        let decision = AudioEngine.resolvePendingAutoSwitchDecision(
+            newDefaultUID: "headphones",
+            pendingConnectedDeviceUID: "headphones",
+            autoSwitchToConnectedOutputDevice: false,
+            lastAutoSwitchOverrideTime: nil,
+            now: Date(timeIntervalSince1970: 100)
+        )
+
+        #expect(decision == .restoreConfirmedDefault)
+    }
+
+    @Test("Settled device change is treated as user intent even when the setting is disabled")
+    func pendingAutoSwitchAcceptsSettledUserChange() {
+        let decision = AudioEngine.resolvePendingAutoSwitchDecision(
+            newDefaultUID: "headphones",
+            pendingConnectedDeviceUID: "headphones",
+            autoSwitchToConnectedOutputDevice: false,
+            lastAutoSwitchOverrideTime: Date(timeIntervalSince1970: 98),
+            now: Date(timeIntervalSince1970: 100)
+        )
+
+        #expect(decision == .acceptConnectedDevice)
+    }
+}

--- a/FineTuneTests/SettingsManagerTests.swift
+++ b/FineTuneTests/SettingsManagerTests.swift
@@ -35,6 +35,7 @@ struct SettingsJSONTests {
         original.ddcVolumes = ["monitor-1": 75]
         original.ddcMuteStates = ["monitor-1": false]
         original.autoEQPreampEnabled = false
+        original.appSettings.autoSwitchToConnectedOutputDevice = true
 
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(SettingsManager.Settings.self, from: data)
@@ -48,6 +49,7 @@ struct SettingsJSONTests {
         #expect(decoded.ddcVolumes == original.ddcVolumes)
         #expect(decoded.ddcMuteStates == original.ddcMuteStates)
         #expect(decoded.autoEQPreampEnabled == false)
+        #expect(decoded.appSettings.autoSwitchToConnectedOutputDevice == true)
     }
 
     @Test("Decoding empty JSON produces valid defaults")
@@ -215,8 +217,18 @@ struct AppSettingsDefaultTests {
         #expect(settings.launchAtLogin == false)
         #expect(settings.menuBarIconStyle == .default)
         #expect(settings.defaultNewAppVolume == 1.0)
+        #expect(settings.autoSwitchToConnectedOutputDevice == false)
         #expect(settings.lockInputDevice == true)
         #expect(settings.showDeviceDisconnectAlerts == true)
+    }
+
+    @Test("autoSwitchToConnectedOutputDevice round-trips through JSON as true")
+    func autoSwitchToConnectedOutputDeviceRoundTrip() throws {
+        var settings = AppSettings()
+        settings.autoSwitchToConnectedOutputDevice = true
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+        #expect(decoded.autoSwitchToConnectedOutputDevice == true)
     }
 
     @Test("loudnessEqualizationEnabled defaults to false")

--- a/guide/troubleshooting.md
+++ b/guide/troubleshooting.md
@@ -39,6 +39,8 @@ Some apps use helper processes to play audio rather than the main app process. T
 
 FineTune uses a **device priority list** to decide which output device to use. When a device connects, FineTune only switches to it if it's ranked higher than the current device. When a device disconnects, FineTune falls back to the next highest-priority device that's still connected.
 
+If you want newly connected outputs to take over immediately regardless of priority, enable **Settings → Audio → Auto-Switch New Output**.
+
 By default, devices are added to the bottom of the list in the order they're first seen. Since your Mac's built-in speakers are always connected, they end up at the top (highest priority), so FineTune won't auto-switch to headphones, external speakers, or other devices when they connect.
 
 **This is a one-time setup.** Once you set your preferred order, it's saved permanently and works across app restarts.


### PR DESCRIPTION
## What changed

- added a new `Auto-Switch New Output` audio setting so newly connected output devices can become the active output immediately when the user wants that behavior
- updated output-device connection handling and pending auto-switch reconciliation so FineTune accepts the new device when the setting is enabled instead of forcing the old default back
- documented the new setting in the troubleshooting guide and added focused tests for the switching rules plus AppSettings persistence

## Why

FineTune currently only auto-switches to a connected output when that device is already the highest-priority device. Newly seen outputs are appended to the end of the priority list, so common cases like plugging in headphones require a manual menu bar selection every time.

## Impact

- users can opt into immediate switching for newly connected outputs without changing the existing priority-based behavior for everyone else
- existing disconnect fallback and priority ordering behavior remain unchanged when the new setting is off

## Validation

- `xcodebuild test -project /Users/xiakaiyang/WeChatReplyAssistant/tmp/FineTune/FineTune.xcodeproj -scheme FineTune -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -only-testing:FineTuneTests/OutputDeviceAutoSwitchTests`
- `xcodebuild test -project /Users/xiakaiyang/WeChatReplyAssistant/tmp/FineTune/FineTune.xcodeproj -scheme FineTune -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -only-testing:FineTuneTests/SettingsJSONTests -only-testing:FineTuneTests/AppSettingsDefaultTests`
