### PR TITLE
feat: add hide/show toggle for output and input devices in edit mode

### DIFF
--- a/FineTune/Settings/SettingsManager.swift
+++ b/FineTune/Settings/SettingsManager.swift
@@ -130,6 +130,10 @@ final class SettingsManager {
         var outputDevicePriority: [String] = []
         var inputDevicePriority: [String] = []
 
+        // Hidden devices (UIDs of devices suppressed from the main view)
+        var hiddenOutputDeviceUIDs: Set<String> = []
+        var hiddenInputDeviceUIDs: Set<String> = []
+
         // Per-device AutoEQ headphone correction
         var deviceAutoEQ: [String: AutoEQSelection] = [:]  // deviceUID → selection
         var favoriteAutoEQProfiles: Set<String> = []  // profile IDs
@@ -177,6 +181,8 @@ final class SettingsManager {
                 .mapValues { min($0, 1.0) }
             outputDevicePriority = try c.decodeIfPresent([String].self, forKey: .outputDevicePriority) ?? []
             inputDevicePriority = try c.decodeIfPresent([String].self, forKey: .inputDevicePriority) ?? []
+            hiddenOutputDeviceUIDs = try c.decodeIfPresent(Set<String>.self, forKey: .hiddenOutputDeviceUIDs) ?? []
+            hiddenInputDeviceUIDs = try c.decodeIfPresent(Set<String>.self, forKey: .hiddenInputDeviceUIDs) ?? []
             deviceAutoEQ = try c.decodeIfPresent([String: AutoEQSelection].self, forKey: .deviceAutoEQ) ?? [:]
             favoriteAutoEQProfiles = try c.decodeIfPresent(Set<String>.self, forKey: .favoriteAutoEQProfiles) ?? []
             autoEQPreampEnabled = try c.decodeIfPresent(Bool.self, forKey: .autoEQPreampEnabled) ?? true
@@ -450,6 +456,52 @@ final class SettingsManager {
         guard !settings.inputDevicePriority.contains(uid) else { return }
         settings.inputDevicePriority.append(uid)
         scheduleSave()
+    }
+
+    // MARK: - Hidden Devices
+
+    /// Hides an output device from the main view. Has no effect when the device is the current default.
+    func hideOutputDevice(uid: String) {
+        settings.hiddenOutputDeviceUIDs.insert(uid)
+        scheduleSave()
+    }
+
+    /// Reveals a previously hidden output device in the main view.
+    func unhideOutputDevice(uid: String) {
+        settings.hiddenOutputDeviceUIDs.remove(uid)
+        scheduleSave()
+    }
+
+    /// Returns true if the output device is hidden from the main view.
+    func isOutputDeviceHidden(_ uid: String) -> Bool {
+        settings.hiddenOutputDeviceUIDs.contains(uid)
+    }
+
+    /// All UIDs of hidden output devices.
+    var hiddenOutputDeviceUIDs: Set<String> {
+        settings.hiddenOutputDeviceUIDs
+    }
+
+    /// Hides an input device from the main view. Has no effect when the device is the current default.
+    func hideInputDevice(uid: String) {
+        settings.hiddenInputDeviceUIDs.insert(uid)
+        scheduleSave()
+    }
+
+    /// Reveals a previously hidden input device in the main view.
+    func unhideInputDevice(uid: String) {
+        settings.hiddenInputDeviceUIDs.remove(uid)
+        scheduleSave()
+    }
+
+    /// Returns true if the input device is hidden from the main view.
+    func isInputDeviceHidden(_ uid: String) -> Bool {
+        settings.hiddenInputDeviceUIDs.contains(uid)
+    }
+
+    /// All UIDs of hidden input devices.
+    var hiddenInputDeviceUIDs: Set<String> {
+        settings.hiddenInputDeviceUIDs
     }
 
     /// Merges reordered connected devices into the full priority list, preserving
@@ -733,6 +785,8 @@ final class SettingsManager {
         settings.softwareDeviceSavedVolumes.removeAll()
         settings.outputDevicePriority.removeAll()
         settings.inputDevicePriority.removeAll()
+        settings.hiddenOutputDeviceUIDs.removeAll()
+        settings.hiddenInputDeviceUIDs.removeAll()
         settings.autoEQPreampEnabled = true
         settings.deviceAutoEQ.removeAll()
         settings.favoriteAutoEQProfiles.removeAll()

--- a/FineTune/Settings/SettingsManager.swift
+++ b/FineTune/Settings/SettingsManager.swift
@@ -482,6 +482,18 @@ final class SettingsManager {
         settings.hiddenOutputDeviceUIDs
     }
 
+    /// Flips the hidden state of an output device based on the persisted set.
+    /// Prefer this over read-then-hide/unhide from the view layer, which can
+    /// desync under rapid taps that re-read stale captured state.
+    func toggleOutputDeviceHidden(uid: String) {
+        if settings.hiddenOutputDeviceUIDs.contains(uid) {
+            settings.hiddenOutputDeviceUIDs.remove(uid)
+        } else {
+            settings.hiddenOutputDeviceUIDs.insert(uid)
+        }
+        scheduleSave()
+    }
+
     /// Hides an input device from the main view. Has no effect when the device is the current default.
     func hideInputDevice(uid: String) {
         settings.hiddenInputDeviceUIDs.insert(uid)
@@ -502,6 +514,16 @@ final class SettingsManager {
     /// All UIDs of hidden input devices.
     var hiddenInputDeviceUIDs: Set<String> {
         settings.hiddenInputDeviceUIDs
+    }
+
+    /// Flips the hidden state of an input device based on the persisted set.
+    func toggleInputDeviceHidden(uid: String) {
+        if settings.hiddenInputDeviceUIDs.contains(uid) {
+            settings.hiddenInputDeviceUIDs.remove(uid)
+        } else {
+            settings.hiddenInputDeviceUIDs.insert(uid)
+        }
+        scheduleSave()
     }
 
     /// Merges reordered connected devices into the full priority list, preserving

--- a/FineTune/Views/MenuBarPopupView.swift
+++ b/FineTune/Views/MenuBarPopupView.swift
@@ -482,17 +482,9 @@ struct MenuBarPopupView: View {
                         isHidden: isDeviceHidden,
                         onToggleHidden: {
                             if showingInputDevices {
-                                if audioEngine.settingsManager.isInputDeviceHidden(device.uid) {
-                                    audioEngine.settingsManager.unhideInputDevice(uid: device.uid)
-                                } else {
-                                    audioEngine.settingsManager.hideInputDevice(uid: device.uid)
-                                }
+                                audioEngine.settingsManager.toggleInputDeviceHidden(uid: device.uid)
                             } else {
-                                if audioEngine.settingsManager.isOutputDeviceHidden(device.uid) {
-                                    audioEngine.settingsManager.unhideOutputDevice(uid: device.uid)
-                                } else {
-                                    audioEngine.settingsManager.hideOutputDevice(uid: device.uid)
-                                }
+                                audioEngine.settingsManager.toggleOutputDeviceHidden(uid: device.uid)
                             }
                         }
                     )
@@ -1046,20 +1038,28 @@ struct MenuBarPopupView: View {
 
     /// Recomputes sorted output devices, filtering hidden ones.
     /// The current default output device is always kept visible even if hidden.
+    /// Falls back to the unfiltered list if the filter produces an empty
+    /// result — `defaultDeviceUID` can be briefly nil during device switchover
+    /// and we don't want the main view to show zero rows in that window.
     private func updateSortedDevices() {
+        let all = audioEngine.prioritySortedOutputDevices
         let defaultUID = deviceVolumeMonitor.defaultDeviceUID
-        sortedDevices = audioEngine.prioritySortedOutputDevices.filter { device in
+        let filtered = all.filter { device in
             device.uid == defaultUID || !audioEngine.settingsManager.isOutputDeviceHidden(device.uid)
         }
+        sortedDevices = filtered.isEmpty ? all : filtered
     }
 
     /// Recomputes sorted input devices, filtering hidden ones.
     /// The current default input device is always kept visible even if hidden.
+    /// Empty-filter fallback mirrors `updateSortedDevices`.
     private func updateSortedInputDevices() {
+        let all = audioEngine.prioritySortedInputDevices
         let defaultUID = deviceVolumeMonitor.defaultInputDeviceUID
-        sortedInputDevices = audioEngine.prioritySortedInputDevices.filter { device in
+        let filtered = all.filter { device in
             device.uid == defaultUID || !audioEngine.settingsManager.isInputDeviceHidden(device.uid)
         }
+        sortedInputDevices = filtered.isEmpty ? all : filtered
     }
 
     /// Opens a file panel to import a ParametricEQ.txt for a device

--- a/FineTune/Views/MenuBarPopupView.swift
+++ b/FineTune/Views/MenuBarPopupView.swift
@@ -460,6 +460,9 @@ struct MenuBarPopupView: View {
                     ? deviceVolumeMonitor.defaultInputDeviceID
                     : deviceVolumeMonitor.defaultDeviceID
                 ForEach(Array(editableDeviceOrder.enumerated()), id: \.element.uid) { index, device in
+                    let isDeviceHidden = showingInputDevices
+                        ? audioEngine.settingsManager.isInputDeviceHidden(device.uid)
+                        : audioEngine.settingsManager.isOutputDeviceHidden(device.uid)
                     DeviceEditRow(
                         device: device,
                         priorityIndex: index,
@@ -474,6 +477,22 @@ struct MenuBarPopupView: View {
                                     fromOffsets: IndexSet(integer: fromIndex),
                                     toOffset: newIndex > fromIndex ? newIndex + 1 : newIndex
                                 )
+                            }
+                        },
+                        isHidden: isDeviceHidden,
+                        onToggleHidden: {
+                            if showingInputDevices {
+                                if audioEngine.settingsManager.isInputDeviceHidden(device.uid) {
+                                    audioEngine.settingsManager.unhideInputDevice(uid: device.uid)
+                                } else {
+                                    audioEngine.settingsManager.hideInputDevice(uid: device.uid)
+                                }
+                            } else {
+                                if audioEngine.settingsManager.isOutputDeviceHidden(device.uid) {
+                                    audioEngine.settingsManager.unhideOutputDevice(uid: device.uid)
+                                } else {
+                                    audioEngine.settingsManager.hideOutputDevice(uid: device.uid)
+                                }
                             }
                         }
                     )
@@ -927,9 +946,11 @@ struct MenuBarPopupView: View {
                 updateSortedDevices()
             }
         } else {
-            // Entering edit mode: copy the current tab's sorted devices
+            // Entering edit mode: use the full (unfiltered) device list so hidden devices are also shown.
             wasEditingInputDevices = showingInputDevices
-            editableDeviceOrder = showingInputDevices ? sortedInputDevices : sortedDevices
+            editableDeviceOrder = showingInputDevices
+                ? audioEngine.prioritySortedInputDevices
+                : audioEngine.prioritySortedOutputDevices
             isEditingDevicePriority = true
         }
     }
@@ -1023,14 +1044,22 @@ struct MenuBarPopupView: View {
 
     // MARK: - Helpers
 
-    /// Recomputes sorted output devices using priority order
+    /// Recomputes sorted output devices, filtering hidden ones.
+    /// The current default output device is always kept visible even if hidden.
     private func updateSortedDevices() {
-        sortedDevices = audioEngine.prioritySortedOutputDevices
+        let defaultUID = deviceVolumeMonitor.defaultDeviceUID
+        sortedDevices = audioEngine.prioritySortedOutputDevices.filter { device in
+            device.uid == defaultUID || !audioEngine.settingsManager.isOutputDeviceHidden(device.uid)
+        }
     }
 
-    /// Recomputes sorted input devices using priority order
+    /// Recomputes sorted input devices, filtering hidden ones.
+    /// The current default input device is always kept visible even if hidden.
     private func updateSortedInputDevices() {
-        sortedInputDevices = audioEngine.prioritySortedInputDevices
+        let defaultUID = deviceVolumeMonitor.defaultInputDeviceUID
+        sortedInputDevices = audioEngine.prioritySortedInputDevices.filter { device in
+            device.uid == defaultUID || !audioEngine.settingsManager.isInputDeviceHidden(device.uid)
+        }
     }
 
     /// Opens a file panel to import a ParametricEQ.txt for a device

--- a/FineTune/Views/Rows/DeviceEditRow.swift
+++ b/FineTune/Views/Rows/DeviceEditRow.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import AppKit
 
 /// Simplified device row for priority edit mode.
-/// Shows drag handle, priority number, device icon + name, and DEFAULT badge.
+/// Shows drag handle, priority number, device icon + name, DEFAULT badge, hide toggle, and UID copy.
 struct DeviceEditRow: View {
     let device: AudioDevice
     let priorityIndex: Int
@@ -11,6 +11,9 @@ struct DeviceEditRow: View {
     let isInputDevice: Bool
     let deviceCount: Int
     let onReorder: (Int) -> Void
+
+    let isHidden: Bool
+    let onToggleHidden: () -> Void
 
     @State private var copied = false
 
@@ -63,6 +66,27 @@ struct DeviceEditRow: View {
                     )
             }
 
+            // Hide/show toggle button
+            // Disabled for the current default device — it stays visible while it's the default.
+            Button {
+                onToggleHidden()
+            } label: {
+                Image(systemName: isHidden ? "eye.slash" : "eye")
+                    .font(.system(size: 11))
+                    .foregroundStyle(
+                        isDefault
+                            ? DesignTokens.Colors.textTertiary.opacity(0.4)
+                            : (isHidden ? Color.orange : DesignTokens.Colors.textTertiary)
+                    )
+                    .contentTransition(.symbolEffect(.replace))
+            }
+            .buttonStyle(.plain)
+            .disabled(isDefault)
+            .help(isDefault
+                ? "Cannot hide the default device"
+                : (isHidden ? "Show in main view" : "Hide from main view")
+            )
+
             // Copy UID button (always at far right)
             Button {
                 NSPasteboard.general.clearContents()
@@ -82,9 +106,12 @@ struct DeviceEditRow: View {
             .help("Copy UID")
         }
         .frame(height: DesignTokens.Dimensions.rowContentHeight)
+        .opacity(isHidden && !isDefault ? 0.5 : 1.0)
+        .animation(.easeOut(duration: 0.2), value: isHidden)
         .hoverableRow()
     }
 }
+
 
 // MARK: - Editable Priority Number
 

--- a/FineTune/Views/Rows/DeviceEditRow.swift
+++ b/FineTune/Views/Rows/DeviceEditRow.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import AppKit
 
 /// Simplified device row for priority edit mode.
-/// Shows drag handle, priority number, device icon + name, DEFAULT badge, hide toggle, and UID copy.
+/// Shows drag handle, priority number, device icon + name, DEFAULT badge, hide toggle, and UID copy button.
 struct DeviceEditRow: View {
     let device: AudioDevice
     let priorityIndex: Int
@@ -76,7 +76,7 @@ struct DeviceEditRow: View {
                     .foregroundStyle(
                         isDefault
                             ? DesignTokens.Colors.textTertiary.opacity(0.4)
-                            : (isHidden ? Color.orange : DesignTokens.Colors.textTertiary)
+                            : (isHidden ? DesignTokens.Colors.mutedIndicator : DesignTokens.Colors.textTertiary)
                     )
                     .contentTransition(.symbolEffect(.replace))
             }
@@ -111,7 +111,6 @@ struct DeviceEditRow: View {
         .hoverableRow()
     }
 }
-
 
 // MARK: - Editable Priority Number
 

--- a/FineTuneTests/SettingsManagerTests.swift
+++ b/FineTuneTests/SettingsManagerTests.swift
@@ -35,6 +35,8 @@ struct SettingsJSONTests {
         original.ddcVolumes = ["monitor-1": 75]
         original.ddcMuteStates = ["monitor-1": false]
         original.autoEQPreampEnabled = false
+        original.hiddenOutputDeviceUIDs = ["uid-hidden-out-1", "uid-hidden-out-2"]
+        original.hiddenInputDeviceUIDs = ["uid-hidden-in-1"]
 
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(SettingsManager.Settings.self, from: data)
@@ -48,6 +50,8 @@ struct SettingsJSONTests {
         #expect(decoded.ddcVolumes == original.ddcVolumes)
         #expect(decoded.ddcMuteStates == original.ddcMuteStates)
         #expect(decoded.autoEQPreampEnabled == false)
+        #expect(decoded.hiddenOutputDeviceUIDs == original.hiddenOutputDeviceUIDs)
+        #expect(decoded.hiddenInputDeviceUIDs == original.hiddenInputDeviceUIDs)
     }
 
     @Test("Decoding empty JSON produces valid defaults")
@@ -60,6 +64,8 @@ struct SettingsJSONTests {
         #expect(decoded.appMutes.isEmpty)
         #expect(decoded.systemSoundsFollowsDefault == true)
         #expect(decoded.autoEQPreampEnabled == true)
+        #expect(decoded.hiddenOutputDeviceUIDs.isEmpty)
+        #expect(decoded.hiddenInputDeviceUIDs.isEmpty)
     }
 
     @Test("Decoding with extra unknown keys is tolerated")
@@ -259,6 +265,75 @@ struct AppSettingsDefaultTests {
         #expect(manager.appSettings.loudnessEqualizationEnabled == true)
     }
 
+}
+
+// MARK: - Hidden Devices
+
+@Suite("SettingsManager — hidden device UIDs")
+@MainActor
+struct SettingsManagerHiddenDevicesTests {
+
+    private func makeManager() -> SettingsManager {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        return SettingsManager(directory: tempDir)
+    }
+
+    @Test("hideOutputDevice / unhideOutputDevice / isOutputDeviceHidden round-trip")
+    func outputHideUnhideParity() {
+        let m = makeManager()
+        let uid = "uid-output-1"
+
+        #expect(m.isOutputDeviceHidden(uid) == false)
+        m.hideOutputDevice(uid: uid)
+        #expect(m.isOutputDeviceHidden(uid) == true)
+        #expect(m.hiddenOutputDeviceUIDs.contains(uid))
+        m.unhideOutputDevice(uid: uid)
+        #expect(m.isOutputDeviceHidden(uid) == false)
+        #expect(m.hiddenOutputDeviceUIDs.contains(uid) == false)
+    }
+
+    @Test("hideInputDevice / unhideInputDevice / isInputDeviceHidden round-trip")
+    func inputHideUnhideParity() {
+        let m = makeManager()
+        let uid = "uid-input-1"
+
+        #expect(m.isInputDeviceHidden(uid) == false)
+        m.hideInputDevice(uid: uid)
+        #expect(m.isInputDeviceHidden(uid) == true)
+        m.unhideInputDevice(uid: uid)
+        #expect(m.isInputDeviceHidden(uid) == false)
+    }
+
+    @Test("toggleOutputDeviceHidden flips based on persisted state")
+    func toggleOutputFlipsFromPersisted() {
+        let m = makeManager()
+        let uid = "uid-output-2"
+
+        m.toggleOutputDeviceHidden(uid: uid)
+        #expect(m.isOutputDeviceHidden(uid) == true)
+        m.toggleOutputDeviceHidden(uid: uid)
+        #expect(m.isOutputDeviceHidden(uid) == false)
+    }
+
+    @Test("toggleInputDeviceHidden flips based on persisted state")
+    func toggleInputFlipsFromPersisted() {
+        let m = makeManager()
+        let uid = "uid-input-2"
+
+        m.toggleInputDeviceHidden(uid: uid)
+        #expect(m.isInputDeviceHidden(uid) == true)
+        m.toggleInputDeviceHidden(uid: uid)
+        #expect(m.isInputDeviceHidden(uid) == false)
+    }
+
+    @Test("Hidden output and input sets are independent")
+    func outputAndInputSetsIndependent() {
+        let m = makeManager()
+        m.hideOutputDevice(uid: "shared-uid")
+        #expect(m.isOutputDeviceHidden("shared-uid") == true)
+        #expect(m.isInputDeviceHidden("shared-uid") == false)
+    }
 }
 
 // MARK: - MenuBarIconStyle


### PR DESCRIPTION
## What
Adds a hide/show eye icon button next to the copy UID button in the device edit (priority) mode.

## Why
Users may have devices connected that they never want to see in the main view (e.g. monitor speakers, unused inputs). This feature lets them suppress those devices without removing them from the system.

## How it works
- In edit mode, each device row now has an `eye` / `eye.slash` button
- Tapping it hides the device from the main list (persisted to disk)
- Hidden devices are shown dimmed in edit mode so they can still be managed
- The current default device cannot be hidden — if a hidden device becomes the default, it reappears automatically until the default changes

## Files changed
- `SettingsManager.swift` — new `hiddenOutputDeviceUIDs` / `hiddenInputDeviceUIDs` sets with CRUD + persistence
- `DeviceEditRow.swift` — eye toggle button with animation
- `MenuBarPopupView.swift` — filtering in normal view, unfiltered list in edit mode
