### PR TITLE
feat(audio): add opt-in setting to show virtual output devices

### DIFF
--- a/FineTune/Audio/Engine/AudioEngine.swift
+++ b/FineTune/Audio/Engine/AudioEngine.swift
@@ -206,7 +206,7 @@ final class AudioEngine {
             realDeviceMonitor = provider as? AudioDeviceMonitor
             self.deviceMonitor = provider
         } else {
-            let monitor = AudioDeviceMonitor()
+            let monitor = AudioDeviceMonitor(settingsManager: manager)
             realDeviceMonitor = monitor
             self.deviceMonitor = monitor
         }

--- a/FineTune/Audio/Monitors/AudioDeviceMonitor.swift
+++ b/FineTune/Audio/Monitors/AudioDeviceMonitor.swift
@@ -46,6 +46,12 @@ final class AudioDeviceMonitor: AudioDeviceProviding {
 
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "FineTune", category: "AudioDeviceMonitor")
 
+    private let settingsManager: SettingsManager
+
+    init(settingsManager: SettingsManager) {
+        self.settingsManager = settingsManager
+    }
+
     private var deviceListListenerBlock: AudioObjectPropertyListenerBlock?
     private var deviceListAddress = AudioObjectPropertyAddress(
         mSelector: kAudioHardwarePropertyDevices,
@@ -102,6 +108,12 @@ final class AudioDeviceMonitor: AudioDeviceProviding {
         removeAllDataSourceListeners()
     }
 
+    /// Re-enumerates the device list and fires connect/disconnect callbacks for any
+    /// devices whose visibility changed due to a settings toggle (e.g. show virtual outputs).
+    func refreshForSettingsChange() {
+        handleDeviceListChanged()
+    }
+
     /// O(1) lookup by device UID (output devices)
     func device(for uid: String) -> AudioDevice? {
         devicesByUID[uid]
@@ -138,8 +150,13 @@ final class AudioDeviceMonitor: AudioDeviceProviding {
                 // but skip FineTune's own internal aggregates used for process taps
                 if deviceID.isAggregateDevice() && name.hasPrefix("FineTune-") { continue }
 
-                // Output devices - filter virtual devices (avoid clutter from Teams Audio, BlackHole, etc.)
-                if deviceID.hasOutputStreams() && !deviceID.isVirtualDevice() {
+                // Output devices - virtual devices are hidden by default (Teams Audio, BlackHole, etc.);
+                // user can opt in via settings, and zombie virtuals are always filtered out.
+                let isVirtualOutput = deviceID.isVirtualDevice()
+                let includeVirtualOutput = isVirtualOutput
+                    && settingsManager.appSettings.showVirtualOutputDevices
+                    && deviceID.isDeviceAlive()
+                if deviceID.hasOutputStreams() && (!isVirtualOutput || includeVirtualOutput) {
                     // Try Core Audio icon first (via LRU cache), fall back to SF Symbol
                     let icon = DeviceIconCache.shared.icon(for: uid) {
                         deviceID.readDeviceIcon()

--- a/FineTune/Settings/SettingsManager.swift
+++ b/FineTune/Settings/SettingsManager.swift
@@ -60,6 +60,7 @@ struct AppSettings: Codable, Equatable {
 
     // Device Volume
     var softwareDeviceVolumeEnabled: Bool = false  // Software volume for unsupported output devices (opt-in)
+    var showVirtualOutputDevices: Bool = false     // Show virtual output devices (e.g. BlackHole, Loopback) in the list (opt-in)
 
     // Notifications
     var showDeviceDisconnectAlerts: Bool = true
@@ -82,6 +83,7 @@ struct AppSettings: Codable, Equatable {
         defaultNewAppVolume = try c.decodeIfPresent(Float.self, forKey: .defaultNewAppVolume) ?? 1.0
         lockInputDevice = try c.decodeIfPresent(Bool.self, forKey: .lockInputDevice) ?? true
         softwareDeviceVolumeEnabled = try c.decodeIfPresent(Bool.self, forKey: .softwareDeviceVolumeEnabled) ?? false
+        showVirtualOutputDevices = try c.decodeIfPresent(Bool.self, forKey: .showVirtualOutputDevices) ?? false
         showDeviceDisconnectAlerts = try c.decodeIfPresent(Bool.self, forKey: .showDeviceDisconnectAlerts) ?? true
         loudnessCompensationEnabled = try c.decodeIfPresent(Bool.self, forKey: .loudnessCompensationEnabled) ?? false
         loudnessEqualizationEnabled = try c.decodeIfPresent(Bool.self, forKey: .loudnessEqualizationEnabled) ?? false

--- a/FineTune/Views/MenuBarPopupView.swift
+++ b/FineTune/Views/MenuBarPopupView.swift
@@ -164,6 +164,9 @@ struct MenuBarPopupView: View {
             if oldValue.softwareDeviceVolumeEnabled != newValue.softwareDeviceVolumeEnabled {
                 audioEngine.handleSoftwareVolumeSettingChanged()
             }
+            if oldValue.showVirtualOutputDevices != newValue.showVirtualOutputDevices {
+                (audioEngine.deviceMonitor as? AudioDeviceMonitor)?.refreshForSettingsChange()
+            }
             if oldValue.loudnessCompensationEnabled != newValue.loudnessCompensationEnabled {
                 audioEngine.setLoudnessCompensationEnabled(newValue.loudnessCompensationEnabled)
             }

--- a/FineTune/Views/Settings/SettingsView.swift
+++ b/FineTune/Views/Settings/SettingsView.swift
@@ -96,6 +96,13 @@ struct SettingsView: View {
             )
 
             SettingsToggleRow(
+                icon: "square.stack.3d.up",
+                title: "Show Virtual Output Devices",
+                description: "Include virtual outputs like BlackHole and Loopback in the device list",
+                isOn: $settings.showVirtualOutputDevices
+            )
+
+            SettingsToggleRow(
                 icon: "mic",
                 title: "Lock Input Device",
                 description: "Prevent auto-switching when devices connect",


### PR DESCRIPTION
## Summary
- Adds a **Show Virtual Output Devices** toggle (off by default) in Settings → Audio, so users can opt in to routing through virtual outputs like BlackHole, Loopback, or Aggregate Devices without the Teams Audio / ScreenCaptureKit clutter that motivated the original filter
- Virtual outputs are still filtered when the setting is on if they're not alive (mirrors the existing rule for virtual inputs), so dormant system virtuals stay hidden
- Pairs naturally with the existing **Software Volume for Unsupported Devices** setting, which was designed for exactly these devices (no hardware volume)

## Implementation notes
- `AudioDeviceMonitor` now takes `SettingsManager` via init and reads `appSettings.showVirtualOutputDevices` when refreshing the device list
- A new `refreshForSettingsChange()` triggers the existing `handleDeviceListChanged()` path so connect/disconnect callbacks fire immediately on toggle — `DeviceVolumeMonitor` etc. attach listeners without waiting for the next HAL event
- `AppSettings` decoder falls back to `false` for missing key, so existing users keep current behavior

## Test plan
- [ ] Toggle setting off: BlackHole / Loopback / Aggregate outputs are hidden (default behavior preserved)
- [ ] Toggle setting on: virtual outputs appear in device list immediately
- [ ] Teams Audio (registered but Teams not running) stays hidden even with setting on (zombie filter)
- [ ] Route an app to a virtual output, verify audio flows
- [ ] Hot-plug a real device while setting is on, ensure no regressions
- [ ] Restart app, verify setting persists