### PR TITLE
fix: software fallback during ddc detection

### DIFF
--- a/FineTune/Audio/Monitors/DeviceVolumeMonitor.swift
+++ b/FineTune/Audio/Monitors/DeviceVolumeMonitor.swift
@@ -178,13 +178,8 @@ final class DeviceVolumeMonitor: DeviceVolumeProviding {
         }
 
         #if !APP_STORE
-        if let ddcController {
-            if !ddcController.probeCompleted {
-                return .hardware
-            }
-            if ddcController.isDDCBacked(deviceID) {
-                return .ddc
-            }
+        if let ddcController, ddcController.isDDCBacked(deviceID) {
+            return .ddc
         }
         #endif
 


### PR DESCRIPTION
I couldn't adjust the master volume for a couple of my audio sources so I used AI to look into it. This is the fix it came up with and it works for me. I'm not sure what your policy on AI is so I understand if this can't be merged.

AI summary:
```
Ensures volume control immediately defaults to working software gain while the background DDC probe is running. This prevents monitors from getting stuck in a broken hardware volume state during app startup.
```