### PR TITLE
fix(loudness): add preamp cut to prevent clipping from compensation boost

### DIFF
--- a/FineTune/Audio/Loudness/LoudnessCompensator.swift
+++ b/FineTune/Audio/Loudness/LoudnessCompensator.swift
@@ -47,6 +47,11 @@ final class LoudnessCompensator: BiquadProcessor, @unchecked Sendable {
     /// Phon level used for the last coefficient computation.
     private var _currentPhon: Double = 80.0
 
+    /// Preamp gain (linear) applied before the biquad cascade to prevent clipping.
+    /// Equal to the inverse of the peak boost so that no frequency exceeds the
+    /// original signal level after compensation.
+    private nonisolated(unsafe) var _preampGain: Float = 1.0
+
     // MARK: - Init
 
     init(sampleRate: Double) {
@@ -82,10 +87,14 @@ final class LoudnessCompensator: BiquadProcessor, @unchecked Sendable {
         // Bypass when all gains are negligible (near reference level)
         let allNegligible = gains.allSatisfy { abs($0) < 0.1 }
         if allNegligible {
+            _preampGain = 1.0
             setEnabled(false)
             swapSetup(nil)
             return
         }
+
+        let peakBoostDB = Self.peakRealizedResponseDB(sectionGains: gains.map { Double($0) }, sampleRate: sampleRate)
+        _preampGain = peakBoostDB > 0 ? powf(10.0, Float(-peakBoostDB) / 20.0) : 1.0
 
         let coefficients = Self.coefficientsForBands(gains: gains, sampleRate: sampleRate)
         let newSetup = coefficients.withUnsafeBufferPointer { ptr in
@@ -176,9 +185,19 @@ final class LoudnessCompensator: BiquadProcessor, @unchecked Sendable {
         // Called by updateSampleRate() — recompute for current phon at new sample rate
         let gains = computeBandGains(phon: _currentPhon)
         let allNegligible = gains.allSatisfy { abs($0) < 0.1 }
-        guard !allNegligible else { return nil }
+        guard !allNegligible else {
+            _preampGain = 1.0
+            return nil
+        }
+        let peakBoostDB = Self.peakRealizedResponseDB(sectionGains: gains.map { Double($0) }, sampleRate: sampleRate)
+        _preampGain = peakBoostDB > 0 ? powf(10.0, Float(-peakBoostDB) / 20.0) : 1.0
         let coefficients = Self.coefficientsForBands(gains: gains, sampleRate: sampleRate)
         return (coefficients, Self.bandCount)
+    }
+
+    override func preProcess(output: UnsafeMutablePointer<Float>, frameCount: Int) {
+        var preamp = _preampGain
+        vDSP_vsmul(output, 1, &preamp, output, 1, vDSP_Length(frameCount * 2))
     }
 
     private static func cascadeMagnitude(coefficients: [Double], sectionCount: Int, omega: Double) -> Double {
@@ -200,6 +219,11 @@ final class LoudnessCompensator: BiquadProcessor, @unchecked Sendable {
         }
 
         return magnitude
+    }
+
+    private static func peakRealizedResponseDB(sectionGains: [Double], sampleRate: Double) -> Double {
+        let response = realizedResponseDB(sectionGains: sectionGains, sampleRate: sampleRate)
+        return max(0.0, response.max() ?? 0.0)
     }
 
     private static func targetCurveDB(forPhon phon: Double) -> [Double] {


### PR DESCRIPTION
Heads-up: This PR and fix was generated by Claude, but I did manually review it and test it! No sloppy unsupervised AI code here :)

## Summary

- **Adds a preamp gain stage to `LoudnessCompensator`** that attenuates the signal by the peak boost of the realized biquad response before the EQ cascade runs, preventing clipping
- Follows the same `BiquadProcessor.preProcess` pattern already used by `AutoEQProcessor`
- Fixes distortion most noticeable on **hardware-volume devices (Bluetooth)** at low-to-moderate listening levels

## Problem

On hardware-volume devices like Bluetooth headphones, the audio signal stays at **full amplitude** in the processing pipeline (volume is controlled by the device, not digitally). Meanwhile, `LoudnessCompensator` sees the low device volume, computes a low phon level, and applies large frequency-dependent boosts (10–20 dB bass/treble at low volumes per ISO 226:2023 contours).

This pushes bass/treble peaks well above unity. The downstream `SoftLimiter` (threshold 0.95, ceiling 1.0 — only 0.05 headroom) then crushes these peaks, causing audible non-linear distortion. The lower the volume, the larger the compensation boost, and the worse the clipping.

## Fix

Before the biquad cascade, apply a preamp cut equal to the inverse of the peak realized response:

```
peakBoostDB = max gain across 96 log-spaced frequencies (20 Hz–20 kHz)
preampGain  = 10^(-peakBoostDB / 20)
```

This ensures no frequency exceeds the original signal level after compensation. The `preProcess` hook (vDSP_vsmul) is RT-safe with zero allocations.

## Related

Partially addresses #302 — the distortion component of the reported audio issues when loudness features are enabled. The volume-pumping behavior described in #302 is a separate concern in `LoudnessEqualizer` (dynamic gain leveler) involving over-aggressive boost settings and measurement/smoothing timing, which would need a separate fix.

## Test plan

- [x] Project builds cleanly (`xcodebuild`, `CODE_SIGNING_ALLOWED=NO`)
- [x] Existing `ISO226ContoursTests` and `ProcessingPipelineTests` pass
- [x] Manual: enable Loudness Compensation, play music over Bluetooth at low volume — bass should sound clean without distortion
- [x] Manual: verify no perceptible volume drop at high volume (preamp ≈ 1.0 near reference level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)