### PR TITLE
feat(audio): Call Ducking Compensation — counter-boost other apps during VoIP calls

### DIFF
--- a/FineTune/Audio/Engine/AudioEngine.swift
+++ b/FineTune/Audio/Engine/AudioEngine.swift
@@ -357,6 +357,7 @@ final class AudioEngine {
             self.applyPersistedSettings()
             self.scheduleStaleCleanup()
             self.voipCallDetector.update(from: apps)
+            self.tearDownVoIPTaps()
         }
 
         // Re-apply every tap's effective volume whenever a call starts/ends.
@@ -749,7 +750,24 @@ final class AudioEngine {
             disabled: settings.disabledCallAppBundleIDs,
             currentApps: processMonitor.activeApps
         )
+        tearDownVoIPTaps()
         refreshAllTapOutputStates()
+    }
+
+    /// Invalidate any live taps on VoIP apps. We don't want our aggregate
+    /// device sitting in the call audio path — macOS's voice-processing mixer
+    /// would treat it as "other audio" and duck the call itself.
+    private func tearDownVoIPTaps() {
+        guard settingsManager.appSettings.callDucking.enabled else { return }
+        for app in apps where voipCallDetector.isVoIPApp(app) {
+            if let tap = taps.removeValue(forKey: app.id) {
+                tap.invalidate()
+                logger.info("Tore down tap on VoIP app to keep call audio out of our pipeline: \(app.name)")
+            }
+            appDeviceRouting.removeValue(forKey: app.id)
+            followsDefault.remove(app.id)
+            appliedPIDs.remove(app.id)
+        }
     }
 
     /// Estimated listening level for loudness compensation: device volume × per-app slider.
@@ -1132,6 +1150,13 @@ final class AudioEngine {
         for app in apps {
             guard !appliedPIDs.contains(app.id) else { continue }
             guard !settingsManager.isIgnored(app.persistenceIdentifier) else { continue }
+            // Never tap VoIP / conferencing apps. Routing call audio through our
+            // aggregate device exposes it to macOS's voice-processing mixer as
+            // "other audio", which then ducks the call itself. Leaving these
+            // apps untapped preserves the system's native voice routing.
+            if settingsManager.appSettings.callDucking.enabled, voipCallDetector.isVoIPApp(app) {
+                continue
+            }
 
             // Load saved device selection mode (single vs multi)
             let savedMode = volumeState.loadSavedDeviceSelectionMode(for: app.id, identifier: app.persistenceIdentifier)

--- a/FineTune/Audio/Engine/AudioEngine.swift
+++ b/FineTune/Audio/Engine/AudioEngine.swift
@@ -15,6 +15,7 @@ final class AudioEngine {
     let settingsManager: SettingsManager
     let autoEQProfileManager: AutoEQProfileManager
     let permission: AudioRecordingPermission
+    let voipCallDetector: VoIPCallDetector
 
     #if !APP_STORE
     let ddcController: DDCController
@@ -187,6 +188,10 @@ final class AudioEngine {
         self.autoEQProfileManager = autoEQProfileManager ?? AutoEQProfileManager()
         self.volumeState = VolumeState(settingsManager: manager)
         self.isAliveCheck = isAlive ?? { $0.isDeviceAlive() }
+        self.voipCallDetector = VoIPCallDetector(
+            extraBundleIDs: manager.appSettings.callDucking.extraCallAppBundleIDs,
+            disabledBundleIDs: manager.appSettings.callDucking.disabledCallAppBundleIDs
+        )
 
         // If a custom deviceProvider is given, use it directly.
         // Otherwise create a real AudioDeviceMonitor (needed by DeviceVolumeMonitor and default tap factory).
@@ -348,8 +353,18 @@ final class AudioEngine {
         }
 
         processMonitor.onAppsChanged = { [weak self] apps in
-            self?.applyPersistedSettings()
-            self?.scheduleStaleCleanup()
+            guard let self else { return }
+            self.applyPersistedSettings()
+            self.scheduleStaleCleanup()
+            self.voipCallDetector.update(from: apps)
+        }
+
+        // Re-apply every tap's effective volume whenever a call starts/ends.
+        // The compensation factor is multiplied into effectiveVolume(for:) below;
+        // refreshAllTapOutputStates pushes the new value to ProcessTapController,
+        // whose existing 30 ms ramp keeps the transition click-free.
+        voipCallDetector.onCallStateChanged = { [weak self] _, _ in
+            self?.refreshAllTapOutputStates()
         }
 
         // Priority order closures — only for concrete AudioDeviceMonitor
@@ -690,21 +705,51 @@ final class AudioEngine {
     }
 
     /// Effective gain for ProcessTapController: app volume × boost, plus optional
-    /// single-device software output gain for software-backed devices.
+    /// single-device software output gain for software-backed devices, plus the
+    /// VoIP call counter-boost when a call is active and this app is not itself
+    /// the call app.
     /// Single-device-routed apps on `.software`-backed devices always receive the
     /// device's software gain; multi-destination routing keeps `appGain` alone
     /// because per-device software gain has no unambiguous meaning across fan-out.
     private func effectiveVolume(for pid: pid_t, deviceUIDs: [String]? = nil) -> Float {
         let appGain = volumeState.getVolume(for: pid) * volumeState.getBoost(for: pid).rawValue
+        let callBoost = callDuckingCompensationFactor(for: pid)
 
         guard let resolvedUIDs = deviceUIDs, resolvedUIDs.count == 1,
               let primaryUID = resolvedUIDs.first,
               let device = deviceMonitor.device(for: primaryUID),
               outputVolumeBackend(for: device.id) == .software else {
-            return appGain
+            return appGain * callBoost
         }
 
-        return appGain * deviceVolumeMonitor.outputProcessingGain(for: device.id)
+        return appGain * deviceVolumeMonitor.outputProcessingGain(for: device.id) * callBoost
+    }
+
+    /// Linear gain multiplier applied to a tapped app to compensate for macOS's
+    /// "communication mode" ducking. Returns 1.0 when the feature is disabled,
+    /// when no VoIP call is in progress, or when `pid` is itself a call app
+    /// (we never amplify the call audio — that would defeat the purpose).
+    ///
+    /// The downstream SoftLimiter in ProcessTapController.processMappedBuffers
+    /// protects against clipping when the boost pushes the chain above 0 dBFS.
+    private func callDuckingCompensationFactor(for pid: pid_t) -> Float {
+        let settings = settingsManager.appSettings.callDucking
+        guard settings.enabled, voipCallDetector.isCallActive else { return 1.0 }
+        if voipCallDetector.activeCallPIDs.contains(pid) { return 1.0 }
+        return pow(10.0, settings.boostDecibels / 20.0)
+    }
+
+    /// Public hook for the settings UI: re-read call-ducking settings from
+    /// `SettingsManager`, reconfigure the detector, and immediately re-apply
+    /// per-tap volumes so the change is heard without restarting the engine.
+    func handleCallDuckingSettingsChanged() {
+        let settings = settingsManager.appSettings.callDucking
+        voipCallDetector.updateBundleIDList(
+            extra: settings.extraCallAppBundleIDs,
+            disabled: settings.disabledCallAppBundleIDs,
+            currentApps: processMonitor.activeApps
+        )
+        refreshAllTapOutputStates()
     }
 
     /// Estimated listening level for loudness compensation: device volume × per-app slider.

--- a/FineTune/Audio/Monitors/VoIPCallDetector.swift
+++ b/FineTune/Audio/Monitors/VoIPCallDetector.swift
@@ -95,13 +95,13 @@ final class VoIPCallDetector {
         var newCallPIDs: Set<pid_t> = []
         var newCallBundleIDs: Set<String> = []
 
-        // Diagnostic dump of every audio-active app so we can see what bundle
-        // IDs / names the process monitor is actually giving us. Helpful for
-        // debugging missed-match cases (e.g. avconferenced reporting a name
-        // we don't have in our allowlist).
+        // Diagnostic dump of every audio-active app so missed-match cases
+        // (e.g. a new VoIP daemon with a name we don't recognise) can be
+        // investigated by raising the log level via the Console.app filter.
+        // `.debug` keeps it out of the default unified-log stream.
         let snapshot = apps.map { "\($0.name)|\($0.bundleID ?? "nil")" }
             .joined(separator: ", ")
-        logger.info("Scanning \(apps.count, privacy: .public) audio-active processes: \(snapshot, privacy: .public)")
+        logger.debug("Scanning \(apps.count, privacy: .public) audio-active processes: \(snapshot, privacy: .public)")
 
         for app in apps {
             let bundleID = app.bundleID?.lowercased()

--- a/FineTune/Audio/Monitors/VoIPCallDetector.swift
+++ b/FineTune/Audio/Monitors/VoIPCallDetector.swift
@@ -1,0 +1,158 @@
+// FineTune/Audio/Monitors/VoIPCallDetector.swift
+//
+// Detects whether a VoIP / conferencing app is currently active so that
+// AudioEngine can compensate for macOS's automatic "communication mode" ducking
+// of all other audio.
+//
+// macOS's ducking is applied inside coreaudiod's voice-processing IO mixer
+// (kAUVoiceIOOtherAudioDuckingConfiguration). There is no public API on Apple
+// Silicon + SIP-enabled systems to bypass it. The pragmatic workaround used
+// here is to counter-boost every other tapped process by the same magnitude
+// while a call is in progress.
+//
+// Detection strategy: filter the audio-active process list (already maintained
+// by AudioProcessMonitor) by bundle ID against a built-in list of well-known
+// VoIP / conferencing apps, plus a user-configurable extension list.
+
+import AppKit
+import AudioToolbox
+import Foundation
+import os
+
+@Observable
+@MainActor
+final class VoIPCallDetector {
+    /// PIDs of audio-active processes recognised as a call.
+    private(set) var activeCallPIDs: Set<pid_t> = []
+
+    /// Bundle IDs of the call apps currently active (lower-cased).
+    private(set) var activeCallBundleIDs: Set<String> = []
+
+    /// Fired when `activeCallPIDs` actually changes.
+    /// Receives `(isAnyCallActive, callPIDs)`.
+    var onCallStateChanged: ((Bool, Set<pid_t>) -> Void)?
+
+    /// True when at least one VoIP app is currently using audio.
+    var isCallActive: Bool { !activeCallPIDs.isEmpty }
+
+    /// Currently-effective allowlist of VoIP bundle IDs (lower-cased).
+    /// Recomputed whenever the user changes settings.
+    private(set) var effectiveBundleIDs: Set<String>
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "FineTune",
+        category: "VoIPCallDetector"
+    )
+
+    init(
+        extraBundleIDs: Set<String> = [],
+        disabledBundleIDs: Set<String> = []
+    ) {
+        self.effectiveBundleIDs = Self.makeEffectiveBundleIDs(
+            extra: extraBundleIDs,
+            disabled: disabledBundleIDs
+        )
+    }
+
+    /// Update the allowlist. Call this when the user edits the bundle-ID list
+    /// in settings. Triggers a re-evaluation against the last-seen process list.
+    func updateBundleIDList(
+        extra: Set<String>,
+        disabled: Set<String>,
+        currentApps: [AudioApp]
+    ) {
+        effectiveBundleIDs = Self.makeEffectiveBundleIDs(extra: extra, disabled: disabled)
+        update(from: currentApps)
+    }
+
+    /// Re-evaluate which apps count as active calls.
+    /// Call this from AudioProcessMonitor.onAppsChanged.
+    func update(from apps: [AudioApp]) {
+        var newCallPIDs: Set<pid_t> = []
+        var newCallBundleIDs: Set<String> = []
+
+        for app in apps {
+            guard let bundleID = app.bundleID?.lowercased() else { continue }
+            if effectiveBundleIDs.contains(bundleID) {
+                newCallPIDs.insert(app.id)
+                newCallBundleIDs.insert(bundleID)
+            }
+        }
+
+        guard newCallPIDs != activeCallPIDs else { return }
+
+        let wasActive = !activeCallPIDs.isEmpty
+        activeCallPIDs = newCallPIDs
+        activeCallBundleIDs = newCallBundleIDs
+        let isActive = !newCallPIDs.isEmpty
+
+        if isActive != wasActive {
+            logger.info(
+                "Call state changed: \(isActive ? "active" : "ended", privacy: .public) — apps: \(newCallBundleIDs.sorted().joined(separator: ", "), privacy: .public)"
+            )
+        }
+
+        onCallStateChanged?(isActive, newCallPIDs)
+    }
+
+    private static func makeEffectiveBundleIDs(
+        extra: Set<String>,
+        disabled: Set<String>
+    ) -> Set<String> {
+        let normalizedExtra = Set(extra.map { $0.lowercased() })
+        let normalizedDisabled = Set(disabled.map { $0.lowercased() })
+        return defaultVoIPBundleIDs
+            .subtracting(normalizedDisabled)
+            .union(normalizedExtra)
+    }
+
+    /// Built-in list of well-known VoIP / video-call / conferencing apps that
+    /// drive Apple's voice-processing IO unit and therefore trigger ducking.
+    /// All entries are lower-cased; comparisons are case-insensitive.
+    static let defaultVoIPBundleIDs: Set<String> = [
+        // Apple
+        "com.apple.facetime",
+        "com.apple.mobilephone",            // Phone (Continuity) on macOS Sequoia+
+        "com.apple.telephonyutilities.callservicesd",
+        "com.apple.avconferenced",          // Daemon hosting FaceTime/Phone audio
+
+        // Meta
+        "net.whatsapp.whatsapp",
+        "net.whatsapp.whatsappdesktop",
+        "com.facebook.archon",              // Messenger
+        "com.facebook.messenger",
+
+        // Microsoft / Google
+        "com.microsoft.teams",
+        "com.microsoft.teams2",
+        "com.skype.skype",
+        "com.skype.skypeforbusiness",
+        "com.google.meet",                  // Standalone Meet app
+        "com.google.duo",
+
+        // Zoom / Webex / GoTo
+        "us.zoom.xos",
+        "us.zoom.zoomclips",
+        "com.cisco.webexmeetingsapp",
+        "com.cisco.webex.meetings",
+        "com.logmein.gotomeeting",
+        "com.bluejeansnet.bluejeans",
+
+        // Discord / Slack / others
+        "com.hnc.discord",
+        "com.hnc.discord.ptb",
+        "com.hnc.discord.canary",
+        "com.tinyspeck.slackmacgap",        // Slack huddles
+        "com.signal.signal",
+        "com.signal.signal-desktop",
+        "org.signal.signal",
+        "com.viber.osx",
+        "com.linecorp.line.line",
+        "com.linecorp.line",
+        "com.tencent.xinwechat",            // WeChat
+        "com.tencent.wechat",
+        "com.jitsi.jitsi-meet",
+        "im.riot.app",                       // Element
+        "chat.rocket.electron",
+    ]
+}

--- a/FineTune/Audio/Monitors/VoIPCallDetector.swift
+++ b/FineTune/Audio/Monitors/VoIPCallDetector.swift
@@ -44,6 +44,11 @@ final class VoIPCallDetector {
         category: "VoIPCallDetector"
     )
 
+    /// Currently-effective allowlist of VoIP process executable names (lower-cased).
+    /// Used as a fallback when the audio-process object reports a nil bundle ID —
+    /// system daemons like `avconferenced` and `callservicesd` rarely have a bundle ID.
+    private(set) var effectiveProcessNames: Set<String>
+
     init(
         extraBundleIDs: Set<String> = [],
         disabledBundleIDs: Set<String> = []
@@ -52,6 +57,7 @@ final class VoIPCallDetector {
             extra: extraBundleIDs,
             disabled: disabledBundleIDs
         )
+        self.effectiveProcessNames = Self.defaultVoIPProcessNames
     }
 
     /// Update the allowlist. Call this when the user edits the bundle-ID list
@@ -65,17 +71,48 @@ final class VoIPCallDetector {
         update(from: currentApps)
     }
 
+    /// Returns true if the given app is in our VoIP allowlist (by bundle ID or
+    /// process name). Used by AudioEngine to skip tap creation for call apps —
+    /// tapping them would route call audio through our aggregate device, which
+    /// macOS's voice-processing mixer then treats as "other audio" and ducks,
+    /// silencing the actual call.
+    func isVoIPApp(_ app: AudioApp) -> Bool {
+        let bundleID = app.bundleID?.lowercased()
+        let processName = app.name.lowercased()
+        let bundleMatch = bundleID.map { effectiveBundleIDs.contains($0) } ?? false
+        let nameMatch = effectiveProcessNames.contains(processName)
+        return bundleMatch || nameMatch
+    }
+
     /// Re-evaluate which apps count as active calls.
     /// Call this from AudioProcessMonitor.onAppsChanged.
+    ///
+    /// Matches on bundle ID first, falls back to process executable name.
+    /// The fallback is essential for `avconferenced` and similar XPC daemons
+    /// whose `kAudioProcessPropertyBundleID` is nil even though they're the
+    /// actual host of FaceTime/Phone call audio.
     func update(from apps: [AudioApp]) {
         var newCallPIDs: Set<pid_t> = []
         var newCallBundleIDs: Set<String> = []
 
+        // Diagnostic dump of every audio-active app so we can see what bundle
+        // IDs / names the process monitor is actually giving us. Helpful for
+        // debugging missed-match cases (e.g. avconferenced reporting a name
+        // we don't have in our allowlist).
+        let snapshot = apps.map { "\($0.name)|\($0.bundleID ?? "nil")" }
+            .joined(separator: ", ")
+        logger.info("Scanning \(apps.count, privacy: .public) audio-active processes: \(snapshot, privacy: .public)")
+
         for app in apps {
-            guard let bundleID = app.bundleID?.lowercased() else { continue }
-            if effectiveBundleIDs.contains(bundleID) {
+            let bundleID = app.bundleID?.lowercased()
+            let processName = app.name.lowercased()
+
+            let bundleMatch = bundleID.map { effectiveBundleIDs.contains($0) } ?? false
+            let nameMatch = effectiveProcessNames.contains(processName)
+
+            if bundleMatch || nameMatch {
                 newCallPIDs.insert(app.id)
-                newCallBundleIDs.insert(bundleID)
+                newCallBundleIDs.insert(bundleID ?? processName)
             }
         }
 
@@ -105,6 +142,19 @@ final class VoIPCallDetector {
             .subtracting(normalizedDisabled)
             .union(normalizedExtra)
     }
+
+    /// Built-in list of well-known VoIP daemon / XPC executable names whose
+    /// `kAudioProcessPropertyBundleID` is typically nil. These are matched on
+    /// `AudioApp.name` (lower-cased) as a fallback when bundle ID lookup fails.
+    ///
+    /// Most importantly: `avconferenced` is the actual audio host for FaceTime
+    /// and Phone calls on macOS — without name matching, the detector would
+    /// boost it as "other audio" and the call itself would clip in our limiter.
+    static let defaultVoIPProcessNames: Set<String> = [
+        "avconferenced",
+        "callservicesd",
+        "telephonyutilities",
+    ]
 
     /// Built-in list of well-known VoIP / video-call / conferencing apps that
     /// drive Apple's voice-processing IO unit and therefore trigger ducking.

--- a/FineTune/Settings/SettingsManager.swift
+++ b/FineTune/Settings/SettingsManager.swift
@@ -187,6 +187,29 @@ enum VolumeHotkeyStep: String, Codable, CaseIterable, Identifiable, CustomString
     }
 }
 
+// MARK: - Call Ducking Compensation
+
+/// Settings for the per-app counter-boost applied while a VoIP / video-call app
+/// is active. This compensates for macOS's automatic "communication mode"
+/// audio ducking (handled inside coreaudiod's voice-processing IO unit), which
+/// cannot be disabled via public API on Apple Silicon with SIP enabled.
+struct CallDuckingCompensation: Codable, Equatable {
+    /// When true, every tapped app that is not itself a VoIP app receives an
+    /// extra `boostDecibels` gain stage while at least one call is in progress.
+    var enabled: Bool = false
+
+    /// Counter-boost magnitude in dB. macOS ducking is roughly ~20 dB by
+    /// default, so the recommended range is 12–24 dB.
+    var boostDecibels: Float = 18.0
+
+    /// User-added bundle IDs that should be treated as call apps in addition
+    /// to the built-in `VoIPCallDetector.defaultVoIPBundleIDs` list.
+    var extraCallAppBundleIDs: Set<String> = []
+
+    /// Built-in bundle IDs the user has explicitly opted out of.
+    var disabledCallAppBundleIDs: Set<String> = []
+}
+
 // MARK: - App-Wide Settings Model
 
 struct AppSettings: Codable, Equatable {
@@ -206,6 +229,7 @@ struct AppSettings: Codable, Equatable {
     // Audio Processing
     var loudnessCompensationEnabled: Bool = false  // ISO 226:2023 equal-loudness contour compensation
     var loudnessEqualizationEnabled: Bool = false  // Real-time loudness equalization
+    var callDucking: CallDuckingCompensation = CallDuckingCompensation()
 
     // Media Keys & HUD
     var hudStyle: HUDStyle = .tahoe                // Visual style of the volume HUD
@@ -239,6 +263,7 @@ struct AppSettings: Codable, Equatable {
         showDeviceDisconnectAlerts = try c.decodeIfPresent(Bool.self, forKey: .showDeviceDisconnectAlerts) ?? true
         loudnessCompensationEnabled = try c.decodeIfPresent(Bool.self, forKey: .loudnessCompensationEnabled) ?? false
         loudnessEqualizationEnabled = try c.decodeIfPresent(Bool.self, forKey: .loudnessEqualizationEnabled) ?? false
+        callDucking = try c.decodeIfPresent(CallDuckingCompensation.self, forKey: .callDucking) ?? CallDuckingCompensation()
         hudStyle = try c.decodeIfPresent(HUDStyle.self, forKey: .hudStyle) ?? .tahoe
         mediaKeyControlEnabled = try c.decodeIfPresent(Bool.self, forKey: .mediaKeyControlEnabled) ?? true
         volumeHotkeyStep = try c.decodeIfPresent(VolumeHotkeyStep.self, forKey: .volumeHotkeyStep) ?? .normal

--- a/FineTune/Settings/SettingsManager.swift
+++ b/FineTune/Settings/SettingsManager.swift
@@ -198,9 +198,12 @@ struct CallDuckingCompensation: Codable, Equatable {
     /// extra `boostDecibels` gain stage while at least one call is in progress.
     var enabled: Bool = false
 
-    /// Counter-boost magnitude in dB. macOS ducking is roughly ~20 dB by
-    /// default, so the recommended range is 12–24 dB.
-    var boostDecibels: Float = 18.0
+    /// Counter-boost magnitude in dB. macOS ducking is roughly ~20 dB at the
+    /// default `AUVoiceIOOtherAudioDuckingConfiguration.Default` level, but
+    /// hardware/route variations mean +14 dB is a safe sweet spot that won't
+    /// push the per-tap `SoftLimiter` into audible compression on already-loud
+    /// material. Users can crank it up if their setup still sounds ducked.
+    var boostDecibels: Float = 14.0
 
     /// User-added bundle IDs that should be treated as call apps in addition
     /// to the built-in `VoIPCallDetector.defaultVoIPBundleIDs` list.

--- a/FineTune/Settings/SettingsManager.swift
+++ b/FineTune/Settings/SettingsManager.swift
@@ -198,12 +198,13 @@ struct CallDuckingCompensation: Codable, Equatable {
     /// extra `boostDecibels` gain stage while at least one call is in progress.
     var enabled: Bool = false
 
-    /// Counter-boost magnitude in dB. macOS ducking is roughly ~20 dB at the
-    /// default `AUVoiceIOOtherAudioDuckingConfiguration.Default` level, but
-    /// hardware/route variations mean +14 dB is a safe sweet spot that won't
-    /// push the per-tap `SoftLimiter` into audible compression on already-loud
-    /// material. Users can crank it up if their setup still sounds ducked.
-    var boostDecibels: Float = 14.0
+    /// Counter-boost magnitude in dB. macOS ducking ranges roughly 10–20 dB
+    /// depending on `AUVoiceIOOtherAudioDuckingConfiguration` level. +12 dB
+    /// is the empirical sweet spot from real-world testing on built-in
+    /// MacBook speakers — high enough to recover most of the lost loudness
+    /// without pushing typical mastered music into the per-tap `SoftLimiter`.
+    /// Users can adjust this in Settings → Audio if their setup needs more.
+    var boostDecibels: Float = 12.0
 
     /// User-added bundle IDs that should be treated as call apps in addition
     /// to the built-in `VoIPCallDetector.defaultVoIPBundleIDs` list.

--- a/FineTune/Views/MenuBarPopupView.swift
+++ b/FineTune/Views/MenuBarPopupView.swift
@@ -116,6 +116,7 @@ struct MenuBarPopupView: View {
                 }
                 Spacer()
                 editPriorityButton
+                callDuckingButton
                 settingsButton
             }
             .padding(.bottom, DesignTokens.Spacing.xs)
@@ -367,6 +368,58 @@ struct MenuBarPopupView: View {
                 .help("Quit FineTune (⌘Q)")
             }
         }
+    }
+
+    // MARK: - Call Ducking Compensation Header Button
+
+    /// Compact icon-only toggle for the VoIP call-ducking compensation feature.
+    /// Sits in the header next to the gear button. The detailed knob (boost
+    /// dB) still lives in Settings → Audio.
+    ///
+    /// Visual state machine:
+    ///   - Disabled (off):  faded phone icon, click to enable
+    ///   - Enabled + idle:  normal phone icon, click to disable
+    ///   - Enabled + active call: filled green phone icon (live indicator)
+    private var callDuckingButton: some View {
+        let enabled = audioEngine.settingsManager.appSettings.callDucking.enabled
+        let active = enabled && audioEngine.voipCallDetector.isCallActive
+        let symbol = active ? "phone.connection.fill" : "phone.connection"
+        let tint: Color = active
+            ? .green
+            : (enabled
+                ? DesignTokens.Colors.interactiveDefault
+                : DesignTokens.Colors.textTertiary)
+        let tooltip: String = {
+            if !enabled {
+                return "Call Ducking Compensation: Off — click to enable"
+            }
+            if active {
+                let names = audioEngine.voipCallDetector.activeCallBundleIDs
+                    .sorted()
+                    .compactMap { $0.split(separator: ".").last.map(String.init) }
+                    .joined(separator: ", ")
+                return "Call Ducking Compensation: Active — boosting other apps to compensate for \(names)"
+            }
+            return "Call Ducking Compensation: Armed — waiting for FaceTime / WhatsApp / Discord / Zoom call"
+        }()
+
+        return Button {
+            audioEngine.settingsManager.appSettings.callDucking.enabled.toggle()
+            audioEngine.handleCallDuckingSettingsChanged()
+        } label: {
+            Image(systemName: symbol)
+        }
+        .buttonStyle(.plain)
+        .font(.system(size: 12))
+        .symbolRenderingMode(.hierarchical)
+        .foregroundStyle(tint)
+        .frame(
+            minWidth: DesignTokens.Dimensions.minTouchTarget,
+            minHeight: DesignTokens.Dimensions.minTouchTarget
+        )
+        .contentShape(Rectangle())
+        .accessibilityLabel("Call Ducking Compensation")
+        .help(tooltip)
     }
 
     // MARK: - Default Devices Status

--- a/FineTune/Views/Settings/Tabs/AudioTab.swift
+++ b/FineTune/Views/Settings/Tabs/AudioTab.swift
@@ -26,6 +26,7 @@ struct AudioTab: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 volumeSection
+                callDuckingSection
                 devicesSection
             }
             .padding(.horizontal, 20)
@@ -45,6 +46,12 @@ struct AudioTab: View {
         }
         .onChange(of: settings.appSettings.loudnessEqualizationEnabled) { _, newValue in
             audioEngine.setLoudnessEqualizationEnabled(newValue)
+        }
+        .onChange(of: settings.appSettings.callDucking.enabled) { _, _ in
+            audioEngine.handleCallDuckingSettingsChanged()
+        }
+        .onChange(of: settings.appSettings.callDucking.boostDecibels) { _, _ in
+            audioEngine.handleCallDuckingSettingsChanged()
         }
     }
 
@@ -71,6 +78,72 @@ struct AudioTab: View {
                     .toggleStyle(.switch)
                     .controlSize(.small)
                     .labelsHidden()
+            }
+        }
+    }
+
+    // MARK: - Call Ducking Compensation
+
+    private var callDuckingBoostBinding: Binding<Float> {
+        Binding(
+            get: { settings.appSettings.callDucking.boostDecibels },
+            set: { settings.appSettings.callDucking.boostDecibels = $0 }
+        )
+    }
+
+    private var callDuckingStatusText: String {
+        guard settings.appSettings.callDucking.enabled else {
+            return "Disabled. Other apps will be ducked during calls."
+        }
+        if audioEngine.voipCallDetector.isCallActive {
+            let names = audioEngine.voipCallDetector.activeCallBundleIDs
+                .sorted()
+                .map { $0.split(separator: ".").last.map(String.init) ?? $0 }
+                .joined(separator: ", ")
+            return "Active — boosting other apps by \(Int(settings.appSettings.callDucking.boostDecibels)) dB to compensate for: \(names)."
+        }
+        return "Idle — will kick in when a recognised call app starts."
+    }
+
+    private var callDuckingSection: some View {
+        SettingsSection("Call Ducking Compensation") {
+            SettingsRow(
+                "Enable",
+                description: "When a VoIP / video call is active, automatically boost every other app to undo macOS's automatic ducking. macOS reduces all other audio by roughly 20 dB during FaceTime / WhatsApp / Zoom / etc. calls — this counter-boost cancels it out."
+            ) {
+                Toggle("", isOn: $settings.appSettings.callDucking.enabled)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .labelsHidden()
+            }
+            SettingsRowDivider()
+            SettingsRow(
+                "Boost Amount",
+                description: "How much to amplify other apps while a call is active. macOS ducks roughly 20 dB by default; start there and adjust to taste."
+            ) {
+                HStack(spacing: DesignTokens.Spacing.sm) {
+                    Slider(
+                        value: Binding(
+                            get: { Double(callDuckingBoostBinding.wrappedValue) },
+                            set: { callDuckingBoostBinding.wrappedValue = Float($0) }
+                        ),
+                        in: 6.0...24.0,
+                        step: 1.0
+                    )
+                    .frame(width: 280)
+                    .disabled(!settings.appSettings.callDucking.enabled)
+                    Text("\(Int(settings.appSettings.callDucking.boostDecibels)) dB")
+                        .font(.system(size: 11, weight: .medium).monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .frame(width: DesignTokens.Dimensions.settingsPercentageWidth, alignment: .trailing)
+                }
+            }
+            SettingsRowDivider()
+            SettingsRow(
+                "Status",
+                description: callDuckingStatusText
+            ) {
+                EmptyView()
             }
         }
     }

--- a/FineTuneTests/VoIPCallDetectorTests.swift
+++ b/FineTuneTests/VoIPCallDetectorTests.swift
@@ -1,0 +1,163 @@
+// FineTuneTests/VoIPCallDetectorTests.swift
+import AppKit
+import AudioToolbox
+import Testing
+@testable import FineTune
+
+@Suite("VoIPCallDetector")
+@MainActor
+struct VoIPCallDetectorTests {
+    /// Build an `AudioApp` skeleton sufficient for detector input. Icon is a
+    /// blank `NSImage` because the detector never reads it.
+    private func makeApp(
+        pid: pid_t,
+        name: String,
+        bundleID: String?
+    ) -> AudioApp {
+        AudioApp(
+            id: pid,
+            processObjectIDs: [AudioObjectID(pid)],
+            name: name,
+            icon: NSImage(),
+            bundleID: bundleID
+        )
+    }
+
+    // MARK: - Bundle-ID matching
+
+    @Test("matches a built-in VoIP bundle ID (case-insensitive)")
+    func builtInBundleIDMatch() {
+        let detector = VoIPCallDetector()
+        let app = makeApp(pid: 100, name: "FaceTime", bundleID: "com.apple.FaceTime")
+        detector.update(from: [app])
+        #expect(detector.isCallActive)
+        #expect(detector.activeCallPIDs == [100])
+        #expect(detector.activeCallBundleIDs == ["com.apple.facetime"])
+    }
+
+    @Test("ignores an app whose bundle ID is not in the allowlist")
+    func unknownBundleIDIgnored() {
+        let detector = VoIPCallDetector()
+        let app = makeApp(pid: 101, name: "Spotify", bundleID: "com.spotify.client")
+        detector.update(from: [app])
+        #expect(!detector.isCallActive)
+        #expect(detector.activeCallPIDs.isEmpty)
+    }
+
+    // MARK: - Name fallback
+
+    @Test("falls back to process name when bundle ID is nil")
+    func nameFallbackWhenBundleIDNil() {
+        // avconferenced sometimes reports a nil bundle ID via the CoreAudio
+        // process-object properties. The detector must still flag it.
+        let detector = VoIPCallDetector()
+        let app = makeApp(pid: 200, name: "avconferenced", bundleID: nil)
+        detector.update(from: [app])
+        #expect(detector.isCallActive)
+        #expect(detector.activeCallPIDs == [200])
+    }
+
+    @Test("name fallback is case-insensitive")
+    func nameFallbackCaseInsensitive() {
+        let detector = VoIPCallDetector()
+        let app = makeApp(pid: 201, name: "AVConferenced", bundleID: nil)
+        detector.update(from: [app])
+        #expect(detector.isCallActive)
+    }
+
+    @Test("non-VoIP daemon with nil bundle ID stays inactive")
+    func unknownNameStaysIdle() {
+        let detector = VoIPCallDetector()
+        let app = makeApp(pid: 202, name: "randomhelperd", bundleID: nil)
+        detector.update(from: [app])
+        #expect(!detector.isCallActive)
+    }
+
+    // MARK: - isVoIPApp predicate
+
+    @Test("isVoIPApp matches both bundle ID and name paths")
+    func isVoIPAppCovers() {
+        let detector = VoIPCallDetector()
+        #expect(detector.isVoIPApp(makeApp(pid: 1, name: "FaceTime", bundleID: "com.apple.FaceTime")))
+        #expect(detector.isVoIPApp(makeApp(pid: 2, name: "avconferenced", bundleID: nil)))
+        #expect(!detector.isVoIPApp(makeApp(pid: 3, name: "Music", bundleID: "com.apple.Music")))
+        #expect(!detector.isVoIPApp(makeApp(pid: 4, name: "Spotify", bundleID: nil)))
+    }
+
+    // MARK: - User-configurable allowlist
+
+    @Test("extra bundle IDs from settings extend the allowlist")
+    func extraBundleIDsExtend() {
+        let detector = VoIPCallDetector(extraBundleIDs: ["org.somefancy.callapp"])
+        let app = makeApp(pid: 300, name: "SomeFancyCallApp", bundleID: "org.somefancy.callapp")
+        detector.update(from: [app])
+        #expect(detector.isCallActive)
+    }
+
+    @Test("disabled bundle IDs from settings remove built-ins")
+    func disabledBundleIDsRemove() {
+        let detector = VoIPCallDetector(
+            extraBundleIDs: [],
+            disabledBundleIDs: ["com.apple.facetime"]
+        )
+        let app = makeApp(pid: 400, name: "FaceTime", bundleID: "com.apple.FaceTime")
+        detector.update(from: [app])
+        // FaceTime is opted out of the allowlist — detector must ignore it.
+        // Name fallback also fails because "facetime" isn't in the default
+        // process-name list (only daemon names are).
+        #expect(!detector.isCallActive)
+    }
+
+    @Test("updateBundleIDList re-evaluates current apps")
+    func updateBundleIDListReevaluates() {
+        let detector = VoIPCallDetector()
+        let app = makeApp(pid: 500, name: "ExoticTool", bundleID: "io.example.exotic")
+
+        // Initially not recognised
+        detector.update(from: [app])
+        #expect(!detector.isCallActive)
+
+        // After the user adds it to the allowlist, it must light up without
+        // waiting for the next process-list refresh.
+        detector.updateBundleIDList(
+            extra: ["io.example.exotic"],
+            disabled: [],
+            currentApps: [app]
+        )
+        #expect(detector.isCallActive)
+        #expect(detector.activeCallPIDs == [500])
+    }
+
+    // MARK: - Callback semantics
+
+    @Test("onCallStateChanged fires only when the PID set changes")
+    func callbackOnlyOnChange() {
+        let detector = VoIPCallDetector()
+        var fireCount = 0
+        detector.onCallStateChanged = { _, _ in fireCount += 1 }
+
+        let app = makeApp(pid: 600, name: "FaceTime", bundleID: "com.apple.FaceTime")
+
+        detector.update(from: [app])
+        #expect(fireCount == 1)
+
+        // Identical set — must not fire again.
+        detector.update(from: [app])
+        #expect(fireCount == 1)
+
+        // Removing the call should fire.
+        detector.update(from: [])
+        #expect(fireCount == 2)
+        #expect(!detector.isCallActive)
+    }
+
+    @Test("multiple concurrent call apps are all reported")
+    func multipleConcurrent() {
+        let detector = VoIPCallDetector()
+        let facetime = makeApp(pid: 700, name: "FaceTime", bundleID: "com.apple.FaceTime")
+        let avc = makeApp(pid: 701, name: "avconferenced", bundleID: nil)
+        detector.update(from: [facetime, avc])
+        #expect(detector.isCallActive)
+        #expect(detector.activeCallPIDs == [700, 701])
+    }
+}


### PR DESCRIPTION
## Problem

macOS automatically reduces ("ducks") the volume of every other audio source by roughly 20 dB whenever a VoIP / video-call app drives Apple's voice-processing IO unit (FaceTime, Phone, WhatsApp, Zoom, Teams, Discord, …). The ducking is applied inside `coreaudiod`'s mixer for the duration of `AUVoiceIOOtherAudioDuckingConfiguration` and **cannot be disabled via any public API** on Apple Silicon with SIP enabled — the legacy `lldb AudioDeviceDuck=0xc3` patch is x86-only and process-level HAL properties for the call daemons are unreachable.

This is the most common reason users reach for SoundSource — their music goes quiet the moment a call comes in. Since FineTune already taps per-process audio with the right APIs and an aggregate-device pipeline, it can compensate for the ducking without users buying a commercial license.

## Approach

Pragmatic counter-boost rather than a true bypass:

1. **`VoIPCallDetector`** observes the existing `AudioProcessMonitor.activeApps` list and matches each entry against an allowlist of well-known VoIP / conferencing bundle IDs (FaceTime, Phone, WhatsApp, Zoom, Teams, Discord, Slack, Skype, Signal, Webex, GoToMeeting, BlueJeans, Jitsi, Element, Rocket.Chat, WeChat, LINE, Viber, Google Meet/Duo) plus a process-name fallback for daemons whose `kAudioProcessPropertyBundleID` is unreliable (`avconferenced`, `callservicesd`, `telephonyutilities`). User-extensible / user-disable-able.

2. **`AudioEngine.effectiveVolume(for:)`** multiplies the per-app gain by `10^(boostDB/20)` whenever the feature is enabled AND a call is active AND the target is not itself the call app. The existing 30 ms volume ramp in `ProcessTapController` keeps the transition click-free; the existing `SoftLimiter` protects against clipping. Default boost is **12 dB** — empirically the sweet spot on built-in MacBook speakers.

3. **`tearDownVoIPTaps()`** invalidates any live tap on a VoIP app and refuses to create new ones while the feature is enabled. Reason: when FineTune routes call audio through its private aggregate device, `coreaudiod`'s voice-processing mixer treats our aggregate output as "other audio" and ducks the call itself, silencing the remote caller. Leaving call apps untapped preserves the system's native voice routing.

4. **Menu-bar header toggle** for one-click enable/disable, with the icon doubling as a live status indicator: faded when off, normal-tint when armed, green-filled when actively boosting. Tooltip exposes the detected call app. Detailed knobs (boost dB, allowlist) live in **Settings → Audio**.

## What's changed

| File | Change |
|------|--------|
| `FineTune/Audio/Monitors/VoIPCallDetector.swift` | NEW — `@Observable @MainActor` detector, ~190 LOC |
| `FineTune/Audio/Engine/AudioEngine.swift` | Wire detector; `effectiveVolume` × call-boost; `tearDownVoIPTaps` |
| `FineTune/Settings/SettingsManager.swift` | New `CallDuckingCompensation` Codable struct in `AppSettings` (boostDecibels, enabled, user allow/deny lists) |
| `FineTune/Views/Settings/Tabs/AudioTab.swift` | "Call Ducking Compensation" settings section (toggle, dB slider 6–24, live status) |
| `FineTune/Views/MenuBarPopupView.swift` | Compact `callDuckingButton` next to `settingsButton` in the popup header |
| `FineTuneTests/VoIPCallDetectorTests.swift` | NEW — 11 cases covering bundle-ID matching, case insensitivity, name-fallback, user allowlist extensions/removals, callback semantics, concurrent calls |

## Testing

- Full `FineTuneTests` suite: 822 cases, 0 failures on macOS 26.3.1 / Apple Silicon
- New `VoIPCallDetectorTests`: 11 cases, all green
- Real-world testing on built-in MacBook speakers with FaceTime + Google Chrome (YouTube): remote caller audio at normal level, music ~3-4 dB short of pre-call loudness at the default 12 dB compensation, no clipping or pumping artefacts

## Known limitations

- Compensation is a constant gain stage, so it can't match macOS's dynamic gain reduction perfectly. We explored a compressor + make-up gain alternative but reverted it — the artefact pattern (post-call gain recovery audible as a "swell-then-settle") was worse than the constant-gain residual.
- Per-tap `SoftLimiter` will engage on already-loud material above ~16 dB of compensation. Default 12 dB stays out of that region for typical mastered music.
- VoIP-app coverage is allowlist-based. Apps not on the list won't trigger the feature — users can extend the list in Settings (UI for this lives in `CallDuckingCompensation.extraCallAppBundleIDs` but isn't surfaced in a row editor yet; PR welcome).
- Browser-based calls (Google Meet via Chrome) are out of scope because we can't distinguish "Chrome is on a Meet call" from "Chrome is playing a YouTube video" without injecting into the page.

## Why not a HAL plug-in / `AudioServerPlugIn`?

The "perfect" solution is what SoundSource does: ship a signed `AudioServerPlugIn` that becomes the user's default output and routes its output without going through `coreaudiod`'s VP-IO mixer. That requires a kex-equivalent permission, a Developer ID signing identity, notarization, and System Settings → Privacy → Audio loading. Out of scope for this PR. The counter-boost approach is a strictly additive change that ships under the same TCC permissions FineTune already requests, and the feature is opt-in.

---

Happy to iterate on naming, the UI placement, or the bundle-ID allowlist — flagging the unconventional approach upfront so a maintainer can sanity-check it before reading code.