### PR TITLE
fix(audio): fix Bluetooth crackling and tap drift during call-mode transitions

### DIFF
--- a/FineTune/Audio/Engine/AudioEngine.swift
+++ b/FineTune/Audio/Engine/AudioEngine.swift
@@ -360,6 +360,11 @@ final class AudioEngine {
             realMonitor.inputPriorityOrder = { [weak self] in
                 self?.settingsManager.inputDevicePriorityOrder ?? []
             }
+            realMonitor.onBTDeviceSampleRateChanged = { [weak self] uid, newRate in
+                Task { @MainActor [weak self] in
+                    await self?.handleBTDeviceSampleRateChanged(uid: uid, newRate: newRate)
+                }
+            }
         }
 
         deviceMonitor.onDeviceDisconnected = { [weak self] deviceUID, deviceName in
@@ -1877,10 +1882,29 @@ final class AudioEngine {
                 try? await Task.sleep(for: .seconds(2))
                 guard !Task.isCancelled, let self else { return }
 
-                // Skip entirely when no taps exist — avoids unnecessary work at idle (#176)
-                guard !self.taps.isEmpty else { continue }
-
                 let now = Date()
+                let activeApps = self.processMonitor.activeApps
+                let activePIDs = Set(activeApps.map { $0.id })
+
+                // Sweep for active apps that have no tap (e.g. tap creation failed during
+                // a previous recreateTap call). Runs even when taps dict is empty so all-tap
+                // failure is recovered without waiting for an external process-list change.
+                var needsRetry = false
+                for app in activeApps {
+                    let pid = app.id
+                    guard self.taps[pid] == nil else { continue }
+                    guard !self.appliedPIDs.contains(pid) else { continue }
+                    if let cooldownEnd = self.tapRecoveryCooldownUntil[pid], now < cooldownEnd {
+                        continue
+                    }
+                    self.logger.warning("[HEALTH] PID \(pid) (\(app.name)) active but tapless — retrying")
+                    self.tapRecoveryCooldownUntil[pid] = now.addingTimeInterval(20)
+                    needsRetry = true
+                }
+                if needsRetry { self.applyPersistedSettings() }
+
+                // Skip tap health-check when no taps exist — avoids unnecessary work at idle (#176)
+                guard !self.taps.isEmpty else { continue }
 
                 for (pid, tap) in self.taps {
                     // Skip muted apps — no callbacks while muted isn't a health signal
@@ -1895,8 +1919,7 @@ final class AudioEngine {
 
                     // Only health-check apps that are actively streaming (isRunning=true).
                     // Paused apps have no callbacks, which is normal — not a health signal.
-                    let isActivelyStreaming = self.processMonitor.activeApps.contains { $0.id == pid }
-                    guard isActivelyStreaming else {
+                    guard activePIDs.contains(pid) else {
                         consecutiveMisses[pid] = 0
                         continue
                     }
@@ -1915,9 +1938,14 @@ final class AudioEngine {
                     }
                 }
 
-                // Prune entries for PIDs no longer tracked
+                // Prune miss counters for taps that no longer exist
                 consecutiveMisses = consecutiveMisses.filter { self.taps[$0.key] != nil }
-                self.tapRecoveryCooldownUntil = self.tapRecoveryCooldownUntil.filter { self.taps[$0.key] != nil }
+
+                // Prune cooldown entries — but keep them for active apps whose tap creation
+                // failed (tapRecoveryCooldownUntil gates the retry above for those PIDs).
+                self.tapRecoveryCooldownUntil = self.tapRecoveryCooldownUntil.filter {
+                    self.taps[$0.key] != nil || activePIDs.contains($0.key)
+                }
             }
         }
     }
@@ -1925,6 +1953,26 @@ final class AudioEngine {
     private func stopHealthMonitor() {
         healthMonitorTask?.cancel()
         healthMonitorTask = nil
+    }
+
+    /// Recreates taps after a BT device switches between A2DP and call mode. The ghost-clock
+    /// strategy is rate-dependent — a 48 kHz ghost on a 24 kHz SCO device causes crackling.
+    private func handleBTDeviceSampleRateChanged(uid: String, newRate: Double) async {
+        logger.info("[RATE] BT output \(uid, privacy: .public) → \(newRate, format: .fixed(precision: 0)) Hz — recreating affected taps")
+
+        let affectedPIDs = taps.compactMap { (pid, tap) -> pid_t? in
+            tap.currentDeviceUIDs.contains(uid) ? pid : nil
+        }
+
+        guard !affectedPIDs.isEmpty else {
+            logger.debug("[RATE] No active taps on device \(uid, privacy: .public)")
+            return
+        }
+
+        for pid in affectedPIDs {
+            logger.info("[RATE] Recreating tap for PID \(pid)")
+            await recreateTap(for: pid)
+        }
     }
 
     /// Tears down and recreates a tap for a given PID, preserving routing and settings.

--- a/FineTune/Audio/Engine/ProcessTapController.swift
+++ b/FineTune/Audio/Engine/ProcessTapController.swift
@@ -272,6 +272,17 @@ final class ProcessTapController: ProcessTapControlling {
 
     // MARK: - Multi-Device Aggregate Configuration
 
+    /// Returns whether the tap's drift compensation should be enabled in the aggregate.
+    /// Disabled when source and output share the same clock domain (BT clock master,
+    /// ghost clock, or virtual source). Defaults to off when the output is unresolvable.
+    static func aggregateDriftCompEnabled(
+        ghostClockUID: String?,
+        isTapSourceVirtual: Bool,
+        isPrimaryBTOutput: Bool
+    ) -> Bool {
+        ghostClockUID == nil && !isTapSourceVirtual && !isPrimaryBTOutput
+    }
+
     /// Builds aggregate device description for synchronized multi-device output.
     /// First device is clock source (no drift compensation), others sync to it via drift compensation.
     ///
@@ -305,7 +316,11 @@ final class ProcessTapController: ProcessTapControlling {
         // looks like drift). On for wired/USB where the crystal domains actually differ.
         // Defaults to off when the device is unresolvable — less wrong on an unknown BT device.
         let isPrimaryBTOutput = audioDeviceID(for: outputUIDs[0])?.isBluetoothDevice() ?? true
-        let tapDriftCompensation = ghostClockUID == nil && !isTapSourceVirtual() && !isPrimaryBTOutput
+        let tapDriftCompensation = ProcessTapController.aggregateDriftCompEnabled(
+            ghostClockUID: ghostClockUID,
+            isTapSourceVirtual: isTapSourceVirtual(),
+            isPrimaryBTOutput: isPrimaryBTOutput
+        )
 
         logger.info("[AGG] \(name, privacy: .public) clock=\(ghostClockUID == nil ? "BT-self" : "ghost", privacy: .public) driftComp=\(tapDriftCompensation)")
 

--- a/FineTune/Audio/Engine/ProcessTapController.swift
+++ b/FineTune/Audio/Engine/ProcessTapController.swift
@@ -274,7 +274,15 @@ final class ProcessTapController: ProcessTapControlling {
 
     /// Builds aggregate device description for synchronized multi-device output.
     /// First device is clock source (no drift compensation), others sync to it via drift compensation.
-    private func buildAggregateDescription(outputUIDs: [String], tapUUID: UUID, name: String) -> [String: Any] {
+    ///
+    /// - Parameter ghostClockUID: When set, drives aggregate I/O timing from this device's crystal clock
+    ///   without routing audio to it (ghost clock technique). When nil, `outputUIDs[0]` is clock master.
+    private func buildAggregateDescription(
+        outputUIDs: [String],
+        tapUUID: UUID,
+        name: String,
+        ghostClockUID: String? = nil
+    ) -> [String: Any] {
         precondition(!outputUIDs.isEmpty, "Must have at least one output device")
 
         // Build sub-device list - first device is clock source
@@ -288,12 +296,23 @@ final class ProcessTapController: ProcessTapControlling {
             ])
         }
 
-        let clockDeviceUID = outputUIDs[0]  // Primary = clock source
+        // Ghost clock: kAudioAggregateDeviceMainSubDeviceKey must always be a sub-device.
+        let clockDeviceUID = ghostClockUID ?? outputUIDs[0]
+
+        // Drift comp must be off when tap source and clock master share a domain: BT output
+        // (both follow the BT clock — enabling fires on the 50ppm BT-vs-crystal offset every
+        // ~0.7 s), ghost clock (both sides are BT-domain), and virtual sources (burst delivery
+        // looks like drift). On for wired/USB where the crystal domains actually differ.
+        // Defaults to off when the device is unresolvable — less wrong on an unknown BT device.
+        let isPrimaryBTOutput = audioDeviceID(for: outputUIDs[0])?.isBluetoothDevice() ?? true
+        let tapDriftCompensation = ghostClockUID == nil && !isTapSourceVirtual() && !isPrimaryBTOutput
+
+        logger.info("[AGG] \(name, privacy: .public) clock=\(ghostClockUID == nil ? "BT-self" : "ghost", privacy: .public) driftComp=\(tapDriftCompensation)")
 
         return [
             kAudioAggregateDeviceNameKey: name,
             kAudioAggregateDeviceUIDKey: UUID().uuidString,
-            kAudioAggregateDeviceMainSubDeviceKey: clockDeviceUID,
+            kAudioAggregateDeviceMainSubDeviceKey: outputUIDs[0],
             kAudioAggregateDeviceClockDeviceKey: clockDeviceUID,
             kAudioAggregateDeviceIsPrivateKey: true,
             kAudioAggregateDeviceIsStackedKey: true,  // Required for multi-device mirroring — HAL feeds same audio to all sub-devices
@@ -301,11 +320,107 @@ final class ProcessTapController: ProcessTapControlling {
             kAudioAggregateDeviceSubDeviceListKey: subDevices,
             kAudioAggregateDeviceTapListKey: [
                 [
-                    kAudioSubTapDriftCompensationKey: true,
+                    kAudioSubTapDriftCompensationKey: tapDriftCompensation,
                     kAudioSubTapUIDKey: tapUUID.uuidString
                 ]
             ]
         ]
+    }
+
+    private func isTapSourceVirtual() -> Bool {
+        guard let uid = preferredTapSourceDeviceUID,
+              let deviceID = audioDeviceID(for: uid) else { return false }
+        return deviceID.isVirtualDevice()
+    }
+
+    /// Returns a built-in device UID to use as ghost clock when primary output is Bluetooth A2DP,
+    /// anchoring aggregate I/O to a crystal clock rather than the BT device's jittery clock.
+    /// Nil for non-BT devices or when no built-in exists (headless Mac Pro).
+    ///
+    /// Excluded for call/voice modes (< 44.1 kHz): 8 kHz CVSD, 16 kHz mSBC, 24 kHz SCO.
+    /// A 48 kHz ghost clock on a 24 kHz SCO sub-device causes I/O period mismatches and crackling.
+    /// In call mode the BT clock is stable enough; tap and output share the same domain so drift
+    /// comp never fires anyway.
+    private func builtInGhostClockUID(forPrimaryUID uid: String) -> String? {
+        guard let deviceID = audioDeviceID(for: uid) else {
+            logger.debug("[CLOCK] ghost skip — device not found: \(uid, privacy: .public)")
+            return nil
+        }
+        guard deviceID.isBluetoothDevice() else {
+            logger.debug("[CLOCK] ghost skip — not BT: \(uid, privacy: .public)")
+            return nil
+        }
+        // Call/voice modes: 8 kHz (CVSD), 16 kHz (mSBC), 24 kHz (SCO). A2DP is 44.1/48 kHz.
+        // rate=0 means the HAL hasn't settled — skip the ghost clock. Applying 48 kHz ghost
+        // to a device that will settle at 24 kHz (SCO) causes crackling. The rate-change
+        // listener recreates the tap once the rate settles.
+        if let rate = try? deviceID.readNominalSampleRate(), rate < 44_100 {
+            logger.info("[CLOCK] ghost skip — BT device at \(rate, format: .fixed(precision: 0)) Hz (call-mode or initialising): \(uid, privacy: .public)")
+            return nil
+        }
+        let ghostUID = deviceMonitor?.outputDevices.first { $0.id.readTransportType() == .builtIn }?.uid
+            ?? AudioDeviceID.readBuiltInOutputDeviceUID()
+        logger.info("[CLOCK] ghost clock for \(uid, privacy: .public) → \(ghostUID ?? "nil (no built-in)", privacy: .public)")
+        return ghostUID
+    }
+
+    /// Destroys the current aggregate, creates a replacement from `desc`, and waits up to `timeout` seconds.
+    /// On success writes the new ID into `aggregateDeviceID`. On failure leaves it `.unknown`.
+    @discardableResult
+    private func replaceAggregate(
+        _ aggregateDeviceID: inout AudioObjectID,
+        desc: [String: Any],
+        timeout: TimeInterval
+    ) -> Bool {
+        let oldID = aggregateDeviceID
+        aggregateDeviceID = .unknown
+        CrashGuard.untrackDevice(oldID)
+        AudioHardwareDestroyAggregateDevice(oldID)
+        var newID: AudioObjectID = .unknown
+        guard AudioHardwareCreateAggregateDevice(desc as CFDictionary, &newID) == noErr else { return false }
+        CrashGuard.trackDevice(newID)
+        guard newID.waitUntilReady(timeout: timeout) else {
+            CrashGuard.untrackDevice(newID)
+            AudioHardwareDestroyAggregateDevice(newID)
+            return false
+        }
+        aggregateDeviceID = newID
+        return true
+    }
+
+    /// Waits for an aggregate to become ready, with BT-aware retry on timeout.
+    /// On failure `aggregateDeviceID` is left `.unknown` (destroyed and zeroed).
+    @discardableResult
+    private func ensureAggregateReady(
+        aggregateDeviceID: inout AudioObjectID,
+        ghostUID: String?,
+        outputUIDs: [String],
+        tapUUID: UUID,
+        name: String
+    ) -> Bool {
+        let isPrimaryBT = audioDeviceID(for: outputUIDs[0])?.isBluetoothDevice() ?? false
+        // BT call-mode (no ghost clock, BT output) needs up to 4 s for SCO firmware negotiation.
+        // A2DP with ghost clock and wired/USB devices are ready within 2 s.
+        let timeout: TimeInterval = (ghostUID == nil && isPrimaryBT) ? 4.0 : 2.0
+        if aggregateDeviceID.waitUntilReady(timeout: timeout) { return true }
+
+        if ghostUID != nil {
+            // Ghost-clock aggregate failed — retry with BT device as clock master.
+            logger.warning("[CLOCK] Ghost-clock aggregate not ready; retrying with BT as clock master")
+            let desc = buildAggregateDescription(outputUIDs: outputUIDs, tapUUID: tapUUID, name: name)
+            return replaceAggregate(&aggregateDeviceID, desc: desc, timeout: 2.0)
+        } else if isPrimaryBT, let fallbackGhost = AudioDeviceID.readBuiltInOutputDeviceUID() {
+            // BT call-mode aggregate failed — try ghost clock as last resort.
+            // SCO needs longer to initialize; 4 s covers the BT firmware handshake that 2 s misses.
+            logger.warning("[CLOCK] BT-only aggregate not ready; retrying with built-in ghost clock")
+            let desc = buildAggregateDescription(outputUIDs: outputUIDs, tapUUID: tapUUID, name: name, ghostClockUID: fallbackGhost)
+            guard replaceAggregate(&aggregateDeviceID, desc: desc, timeout: 4.0) else {
+                logger.error("[CLOCK] Ghost-clock fallback aggregate also not ready after 4 s")
+                return false
+            }
+            return true
+        }
+        return false
     }
 
     private func preferredStereoChannels(for deviceUID: String?) -> (left: Int, right: Int) {
@@ -418,11 +533,12 @@ final class ProcessTapController: ProcessTapControlling {
         logger.debug("Created process tap #\(tapID)")
 
         // Build multi-device aggregate description
-        // First device is clock source, others have drift compensation for sync
+        let ghostUID = builtInGhostClockUID(forPrimaryUID: targetDeviceUIDs[0])
         let description = buildAggregateDescription(
             outputUIDs: targetDeviceUIDs,
             tapUUID: tapDesc.uuid,
-            name: "FineTune-\(app.id)"
+            name: "FineTune-\(app.id)",
+            ghostClockUID: ghostUID
         )
 
         var err: OSStatus
@@ -435,7 +551,13 @@ final class ProcessTapController: ProcessTapControlling {
         primaryResources.aggregateDeviceID = aggID
         CrashGuard.trackDevice(aggID)
 
-        guard primaryResources.aggregateDeviceID.waitUntilReady(timeout: 2.0) else {
+        guard ensureAggregateReady(
+            aggregateDeviceID: &primaryResources.aggregateDeviceID,
+            ghostUID: ghostUID,
+            outputUIDs: targetDeviceUIDs,
+            tapUUID: tapDesc.uuid,
+            name: "FineTune-\(app.id)"
+        ) else {
             cleanupPartialActivation()
             throw NSError(domain: "ProcessTapController", code: -1, userInfo: [NSLocalizedDescriptionKey: "Aggregate device not ready within timeout"])
         }
@@ -770,10 +892,12 @@ final class ProcessTapController: ProcessTapControlling {
         logger.debug("[CROSSFADE] Created secondary tap #\(tapID)")
 
         // Build multi-device aggregate description using helper
+        let ghostUID = builtInGhostClockUID(forPrimaryUID: outputUIDs[0])
         let description = buildAggregateDescription(
             outputUIDs: outputUIDs,
             tapUUID: tapDesc.uuid,
-            name: "FineTune-\(app.id)-secondary"
+            name: "FineTune-\(app.id)-secondary",
+            ghostClockUID: ghostUID
         )
 
         var err: OSStatus
@@ -787,7 +911,13 @@ final class ProcessTapController: ProcessTapControlling {
         secondaryResources.aggregateDeviceID = aggID
         CrashGuard.trackDevice(aggID)
 
-        guard secondaryResources.aggregateDeviceID.waitUntilReady(timeout: 2.0) else {
+        guard ensureAggregateReady(
+            aggregateDeviceID: &secondaryResources.aggregateDeviceID,
+            ghostUID: ghostUID,
+            outputUIDs: outputUIDs,
+            tapUUID: tapDesc.uuid,
+            name: "FineTune-\(app.id)-secondary"
+        ) else {
             secondaryResources.destroy()
             throw CrossfadeError.deviceNotReady
         }
@@ -982,10 +1112,12 @@ final class ProcessTapController: ProcessTapControlling {
         newResources.tapID = tapID
 
         // Build multi-device aggregate description using helper
+        let ghostUID = builtInGhostClockUID(forPrimaryUID: outputUIDs[0])
         let description = buildAggregateDescription(
             outputUIDs: outputUIDs,
             tapUUID: newTapDesc.uuid,
-            name: "FineTune-\(app.id)"
+            name: "FineTune-\(app.id)",
+            ghostClockUID: ghostUID
         )
 
         var err: OSStatus
@@ -998,7 +1130,13 @@ final class ProcessTapController: ProcessTapControlling {
         newResources.aggregateDeviceID = aggID
         CrashGuard.trackDevice(aggID)
 
-        guard newResources.aggregateDeviceID.waitUntilReady(timeout: 2.0) else {
+        guard ensureAggregateReady(
+            aggregateDeviceID: &newResources.aggregateDeviceID,
+            ghostUID: ghostUID,
+            outputUIDs: outputUIDs,
+            tapUUID: newTapDesc.uuid,
+            name: "FineTune-\(app.id)"
+        ) else {
             newResources.destroy()
             throw CrossfadeError.deviceNotReady
         }

--- a/FineTune/Audio/Extensions/AudioDeviceID+Classification.swift
+++ b/FineTune/Audio/Extensions/AudioDeviceID+Classification.swift
@@ -22,6 +22,11 @@ extension AudioDeviceID {
         readTransportType() == .virtual
     }
 
+    func isBluetoothDevice() -> Bool {
+        let t = readTransportType()
+        return t == .bluetooth || t == .bluetoothLE
+    }
+
     func isHidden() -> Bool {
         (try? readBool(kAudioDevicePropertyIsHidden)) ?? false
     }

--- a/FineTune/Audio/Extensions/AudioObjectID+System.swift
+++ b/FineTune/Audio/Extensions/AudioObjectID+System.swift
@@ -81,6 +81,24 @@ extension AudioDeviceID {
     }
 }
 
+// MARK: - Built-In Output Device
+
+extension AudioDeviceID {
+    /// Returns the UID of the first built-in output device, or nil if none exists.
+    /// Built-in devices use a crystal-locked clock and are used as a stable clock source
+    /// for aggregate devices when the primary output is Bluetooth (ghost clock technique).
+    static func readBuiltInOutputDeviceUID() -> String? {
+        guard let deviceIDs = try? AudioObjectID.readDeviceList() else { return nil }
+        for id in deviceIDs {
+            guard id.readTransportType() == .builtIn else { continue }
+            guard !id.isHidden() else { continue }
+            guard let uid = try? id.readDeviceUID() else { continue }
+            return uid
+        }
+        return nil
+    }
+}
+
 // MARK: - Default Input Device
 
 extension AudioDeviceID {

--- a/FineTune/Audio/Monitors/AudioDeviceMonitor.swift
+++ b/FineTune/Audio/Monitors/AudioDeviceMonitor.swift
@@ -56,8 +56,16 @@ final class AudioDeviceMonitor: AudioDeviceProviding {
     private var knownDeviceUIDs: Set<String> = []
     private var knownInputDeviceUIDs: Set<String> = []
 
+    /// Called when a BT output device crosses the A2DP ↔ SCO/HFP sample-rate threshold (44.1 kHz).
+    var onBTDeviceSampleRateChanged: ((_ uid: String, _ newRate: Double) -> Void)?
+
     /// Listeners for kAudioDevicePropertyDataSource changes on built-in devices (headphone jack detection)
     @ObservationIgnored private var dataSourceListeners: [AudioDeviceID: AudioObjectPropertyListenerBlock] = [:]
+
+    /// Listeners for kAudioDevicePropertyNominalSampleRate changes on BT output devices
+    @ObservationIgnored private var sampleRateListeners: [AudioDeviceID: AudioObjectPropertyListenerBlock] = [:]
+    @ObservationIgnored private var lastKnownSampleRates: [AudioDeviceID: Double] = [:]
+    @ObservationIgnored private var sampleRateDebounce: [AudioDeviceID: Task<Void, Never>] = [:]
 
     /// Debounces rapid HAL device-list notifications (e.g. Bluetooth connect fires 2-3 in ~20ms).
     /// Querying device properties during the burst produces HALC_ShellObject errors because
@@ -100,6 +108,7 @@ final class AudioDeviceMonitor: AudioDeviceProviding {
             deviceListListenerBlock = nil
         }
         removeAllDataSourceListeners()
+        removeAllSampleRateListeners()
     }
 
     /// O(1) lookup by device UID (output devices)
@@ -199,6 +208,8 @@ final class AudioDeviceMonitor: AudioDeviceProviding {
             inputDevicesByID = Dictionary(uniqueKeysWithValues: inputDevices.map { ($0.id, $0) })
 
             syncDataSourceListeners(outputDeviceIDs: outputDeviceList.map(\.id))
+            let btOutputIDs = Set(outputDeviceList.filter { $0.id.isBluetoothDevice() }.map(\.id))
+            syncSampleRateListeners(btOutputDeviceIDs: btOutputIDs)
 
         } catch {
             logger.error("Failed to refresh device list: \(error.localizedDescription)")
@@ -252,8 +263,94 @@ final class AudioDeviceMonitor: AudioDeviceProviding {
     }
 
     private func removeAllDataSourceListeners() {
-        for deviceID in dataSourceListeners.keys {
+        for deviceID in Array(dataSourceListeners.keys) {
             removeDataSourceListener(for: deviceID)
+        }
+    }
+
+    /// Installs/removes kAudioDevicePropertyNominalSampleRate listeners on BT output devices
+    /// so A2DP ↔ SCO/HFP mode switches trigger tap recreation.
+    private func syncSampleRateListeners(btOutputDeviceIDs: Set<AudioDeviceID>) {
+        let currentIDs = Set(sampleRateListeners.keys)
+
+        for deviceID in currentIDs.subtracting(btOutputDeviceIDs) {
+            removeSampleRateListener(for: deviceID)
+        }
+
+        for deviceID in btOutputDeviceIDs.subtracting(currentIDs) {
+            guard let uid = devicesByID[deviceID]?.uid else { continue }
+            var address = AudioObjectPropertyAddress(
+                mSelector: kAudioDevicePropertyNominalSampleRate,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+                Task { @MainActor [weak self] in
+                    self?.scheduleSampleRateCheck(forDeviceID: deviceID, uid: uid)
+                }
+            }
+            let status = AudioObjectAddPropertyListenerBlock(deviceID, &address, .main, block)
+            if status == noErr {
+                sampleRateListeners[deviceID] = block
+                lastKnownSampleRates[deviceID] = (try? deviceID.readNominalSampleRate()) ?? 0
+            } else {
+                logger.warning("Failed to add sample rate listener for BT device \(deviceID): \(status)")
+            }
+        }
+    }
+
+    private func scheduleSampleRateCheck(forDeviceID deviceID: AudioDeviceID, uid: String) {
+        sampleRateDebounce[deviceID]?.cancel()
+        sampleRateDebounce[deviceID] = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled, let self else { return }
+            self.checkSampleRateThreshold(forDeviceID: deviceID, uid: uid)
+        }
+    }
+
+    private func checkSampleRateThreshold(forDeviceID deviceID: AudioDeviceID, uid: String) {
+        let newRate = (try? deviceID.readNominalSampleRate()) ?? 0
+        let oldRate = lastKnownSampleRates[deviceID] ?? 0
+        lastKnownSampleRates[deviceID] = newRate
+
+        // Skip transient HAL failures (newRate == 0).
+        guard newRate > 0 else { return }
+
+        if oldRate == 0 {
+            // No valid baseline yet — only act if device settled at A2DP (≥ 44.1 kHz).
+            // The tap was created without ghost clock (rate was 0, indistinguishable from SCO);
+            // rebuilding it now lets builtInGhostClockUID pick the correct strategy.
+            guard newRate >= 44_100 else { return }
+        } else {
+            let wasCallMode = oldRate < 44_100
+            let isCallMode = newRate < 44_100
+            guard wasCallMode != isCallMode else { return }
+        }
+
+        logger.info("[RATE] BT device \(uid, privacy: .public) \(oldRate, format: .fixed(precision: 0)) → \(newRate, format: .fixed(precision: 0)) Hz (call mode: \(newRate < 44_100))")
+        onBTDeviceSampleRateChanged?(uid, newRate)
+    }
+
+    private func removeSampleRateListener(for deviceID: AudioDeviceID) {
+        sampleRateDebounce[deviceID]?.cancel()
+        sampleRateDebounce.removeValue(forKey: deviceID)
+        lastKnownSampleRates.removeValue(forKey: deviceID)
+
+        guard let block = sampleRateListeners.removeValue(forKey: deviceID) else { return }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyNominalSampleRate,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectRemovePropertyListenerBlock(deviceID, &address, .main, block)
+        if status != noErr && status != OSStatus(kAudioHardwareBadObjectError) {
+            logger.warning("Failed to remove sample rate listener for BT device \(deviceID): \(status)")
+        }
+    }
+
+    private func removeAllSampleRateListeners() {
+        for deviceID in Array(sampleRateListeners.keys) {
+            removeSampleRateListener(for: deviceID)
         }
     }
 

--- a/FineTune/Audio/Monitors/AudioDeviceMonitor.swift
+++ b/FineTune/Audio/Monitors/AudioDeviceMonitor.swift
@@ -308,24 +308,21 @@ final class AudioDeviceMonitor: AudioDeviceProviding {
         }
     }
 
+    /// Returns true when the rate change warrants tap recreation. newRate == 0 (HAL
+    /// transient) always suppresses. oldRate == 0 (cold-connect) fires only when the
+    /// device settles at A2DP (≥ 44.1 kHz). Otherwise fires on A2DP ↔ SCO boundary crossings.
+    nonisolated static func isCallModeTransition(oldRate: Double, newRate: Double) -> Bool {
+        guard newRate > 0 else { return false }
+        if oldRate == 0 { return newRate >= 44_100 }
+        return (oldRate < 44_100) != (newRate < 44_100)
+    }
+
     private func checkSampleRateThreshold(forDeviceID deviceID: AudioDeviceID, uid: String) {
         let newRate = (try? deviceID.readNominalSampleRate()) ?? 0
         let oldRate = lastKnownSampleRates[deviceID] ?? 0
         lastKnownSampleRates[deviceID] = newRate
 
-        // Skip transient HAL failures (newRate == 0).
-        guard newRate > 0 else { return }
-
-        if oldRate == 0 {
-            // No valid baseline yet — only act if device settled at A2DP (≥ 44.1 kHz).
-            // The tap was created without ghost clock (rate was 0, indistinguishable from SCO);
-            // rebuilding it now lets builtInGhostClockUID pick the correct strategy.
-            guard newRate >= 44_100 else { return }
-        } else {
-            let wasCallMode = oldRate < 44_100
-            let isCallMode = newRate < 44_100
-            guard wasCallMode != isCallMode else { return }
-        }
+        guard AudioDeviceMonitor.isCallModeTransition(oldRate: oldRate, newRate: newRate) else { return }
 
         logger.info("[RATE] BT device \(uid, privacy: .public) \(oldRate, format: .fixed(precision: 0)) → \(newRate, format: .fixed(precision: 0)) Hz (call mode: \(newRate < 44_100))")
         onBTDeviceSampleRateChanged?(uid, newRate)

--- a/FineTuneTests/BTCallModeThresholdTests.swift
+++ b/FineTuneTests/BTCallModeThresholdTests.swift
@@ -1,0 +1,64 @@
+// FineTuneTests/BTCallModeThresholdTests.swift
+// Tests for AudioDeviceMonitor.isCallModeTransition(oldRate:newRate:).
+// The old threshold (rate <= 16_000) missed AirPods Pro wideband SCO at 24 kHz;
+// the fix raises it to rate < 44_100. Tests cover A2DP ↔ SCO transitions, the
+// 44.1 kHz boundary, the cold-connect path (oldRate == 0), and the newRate == 0
+// HAL-transient sentinel.
+
+import Testing
+import Foundation
+@testable import FineTune
+
+@Suite("AudioDeviceMonitor — BT call-mode transition detection")
+struct BTCallModeThresholdTests {
+
+    // MARK: - A2DP ↔ call-mode transitions
+
+    @Test("A2DP → wideband SCO (48 kHz → 24 kHz) fires: the AirPods Pro bug case")
+    func a2dpToWidebandSCO() {
+        #expect(AudioDeviceMonitor.isCallModeTransition(oldRate: 48_000, newRate: 24_000))
+    }
+
+    @Test("Wideband SCO → A2DP (24 kHz → 48 kHz) fires: call ended")
+    func widebandSCOToA2DP() {
+        #expect(AudioDeviceMonitor.isCallModeTransition(oldRate: 24_000, newRate: 48_000))
+    }
+
+    @Test("44.1 kHz is A2DP, not call-mode: transition to 24 kHz fires")
+    func boundaryIsA2DP() {
+        #expect(AudioDeviceMonitor.isCallModeTransition(oldRate: 44_100, newRate: 24_000))
+    }
+
+    @Test("A2DP quality change (48 kHz → 44.1 kHz) does not fire")
+    func a2dpQualityChange() {
+        #expect(!AudioDeviceMonitor.isCallModeTransition(oldRate: 48_000, newRate: 44_100))
+    }
+
+    @Test("Same-side call-mode rate change (16 kHz mSBC → 24 kHz wideband SCO) does not fire")
+    func callModeToCallMode() {
+        #expect(!AudioDeviceMonitor.isCallModeTransition(oldRate: 16_000, newRate: 24_000))
+    }
+
+    // MARK: - Cold-connect path (oldRate == 0: baseline never read at listener-install time)
+
+    @Test("Cold-connect settling at A2DP (0 → 48 kHz) fires: tap needs ghost clock applied")
+    func coldConnectToA2DP() {
+        #expect(AudioDeviceMonitor.isCallModeTransition(oldRate: 0, newRate: 48_000))
+        #expect(AudioDeviceMonitor.isCallModeTransition(oldRate: 0, newRate: 44_100))
+    }
+
+    @Test("Cold-connect settling at SCO (0 → 24 kHz) does not fire: skip until A2DP")
+    func coldConnectToSCO() {
+        #expect(!AudioDeviceMonitor.isCallModeTransition(oldRate: 0, newRate: 24_000))
+        #expect(!AudioDeviceMonitor.isCallModeTransition(oldRate: 0, newRate: 16_000))
+    }
+
+    // MARK: - HAL transient sentinel (newRate == 0: device still negotiating)
+
+    @Test("newRate = 0 (HAL mid-negotiation) does not fire from either mode")
+    func newRateZeroDoesNotFire() {
+        #expect(!AudioDeviceMonitor.isCallModeTransition(oldRate: 48_000, newRate: 0))
+        #expect(!AudioDeviceMonitor.isCallModeTransition(oldRate: 24_000, newRate: 0))
+        #expect(!AudioDeviceMonitor.isCallModeTransition(oldRate: 0, newRate: 0))
+    }
+}

--- a/FineTuneTests/BTDriftCompensationTests.swift
+++ b/FineTuneTests/BTDriftCompensationTests.swift
@@ -1,0 +1,48 @@
+// FineTuneTests/BTDriftCompensationTests.swift
+// Tests for ProcessTapController.aggregateDriftCompEnabled(...).
+// The missing !isPrimaryBTOutput guard caused the HAL to insert/delete one sample
+// every ~0.7 s on BT call-mode aggregates (50 ppm BT-vs-crystal offset).
+
+import Testing
+import Foundation
+@testable import FineTune
+
+@Suite("ProcessTapController — aggregate drift comp decision")
+struct BTDriftCompensationTests {
+
+    @Test("BT primary output, no ghost clock → disabled (BT is clock master; shared domain)")
+    func btPrimaryDisablesDriftComp() {
+        #expect(!ProcessTapController.aggregateDriftCompEnabled(
+            ghostClockUID: nil,
+            isTapSourceVirtual: false,
+            isPrimaryBTOutput: true
+        ))
+    }
+
+    @Test("Non-BT output, no ghost clock → enabled (different clock domains, drift comp needed)")
+    func nonBTEnablesDriftComp() {
+        #expect(ProcessTapController.aggregateDriftCompEnabled(
+            ghostClockUID: nil,
+            isTapSourceVirtual: false,
+            isPrimaryBTOutput: false
+        ))
+    }
+
+    @Test("Ghost clock present → disabled regardless of output type")
+    func ghostClockDisablesDriftComp() {
+        #expect(!ProcessTapController.aggregateDriftCompEnabled(
+            ghostClockUID: "BuiltIn_Output",
+            isTapSourceVirtual: false,
+            isPrimaryBTOutput: false
+        ))
+    }
+
+    @Test("Virtual source → disabled (burst delivery misread as drift)")
+    func virtualSourceDisablesDriftComp() {
+        #expect(!ProcessTapController.aggregateDriftCompEnabled(
+            ghostClockUID: nil,
+            isTapSourceVirtual: true,
+            isPrimaryBTOutput: false
+        ))
+    }
+}


### PR DESCRIPTION
## Fix Bluetooth crackling and tap drift during call-mode transitions

Been chasing this one for a while. Bluetooth headsets crackle rhythmically when joining a call — the moment the mic activates, the headset switches from A2DP (48 kHz) to wideband SCO (24 kHz) and FineTune's aggregate device setup falls apart. Reproduced consistently on AirPods Pro and Sennheiser ACCENTUM. The fix is general — any BT device that uses SCO/HFP for calls hits the same code paths.

Turned out to be three separate root causes:

**Ghost clock applied to the wrong devices**

The call-mode detection was checking `rate <= 16_000`, which catches old HFP (8/16 kHz) but misses Apple's wideband SCO at 24 kHz entirely. Changed the threshold to `rate < 44_100`. Also made rate=0 (device still negotiating) skip the ghost clock — a device mid-negotiation is more likely heading to call mode than A2DP, and applying a 48 kHz ghost clock to something about to settle at 24 kHz is exactly what causes the crackling. The rate-change listener recreates the tap once the rate settles.

**Drift compensation firing on BT call-mode aggregates**

The drift comp calculation didn't account for BT outputs being their own clock master. With no ghost clock and a non-virtual source it was always evaluating to `true`, so the HAL was inserting/deleting a sample every ~0.7 s to correct the 50 ppm BT-vs-crystal offset. Added `!isPrimaryBTOutput` to the expression — when the BT device is the clock master, tap source and output are in the same domain and drift comp just causes clicks.

**Mode transition happening mid-tap**

An app could have a perfectly good 48 kHz ghost-clock tap running, then the user joins a call and the headset switches to 24 kHz. The existing tap keeps the wrong aggregate strategy until something tears it down. Added a `kAudioDevicePropertyNominalSampleRate` listener on all BT output devices — when the rate crosses the 44.1 kHz boundary in either direction, affected taps get recreated so the strategy is re-evaluated against the actual current rate. 150 ms debounce to let the HAL settle before reading.

**Other changes**

- Replaced the copy-pasted `waitUntilReady(timeout: 2.0)` at three call sites with `ensureAggregateReady`, which handles BT-aware retry: ghost-clock aggregate timeout → retry with BT as clock master; BT-only aggregate timeout → retry with ghost clock (4 s for SCO firmware negotiation)
- Health monitor sweep for apps that end up tapless after a failed `recreateTap` — previously they'd stay silent until the next process-list change
- Guard against spurious tap recreation when `readNominalSampleRate()` returns 0 during a transient HAL error while already in call mode
- Cold-connect baseline fix: when a BT device connects while the HAL is still negotiating (rate=0), the first valid A2DP settle event now triggers tap recreation to apply the ghost clock
- Health monitor tapless sweep now runs even when the `taps` dict is empty, so all-tap-failure scenarios recover without waiting for an external process-list change

**Tested on:** AirPods Pro (24 kHz SCO) and Sennheiser ACCENTUM, across multiple Google Meet calls including leave-and-rejoin cycles. Chrome, Slack, and Meet running simultaneously. No crackling, `driftComp=false` confirmed in logs for all BT output paths.

Closes #63
Closes #66
Closes #315