### PR TITLE
Enable AutoEQ for built-in audio

### DIFF
--- a/FineTune/Audio/Extensions/AudioDeviceID+Classification.swift
+++ b/FineTune/Audio/Extensions/AudioDeviceID+Classification.swift
@@ -65,9 +65,9 @@ nonisolated extension AudioDeviceID {
 // MARK: - AutoEQ Eligibility
 
 extension AudioDeviceID {
-    /// Returns `true` if this device is likely headphones and can benefit from AutoEQ correction.
+    /// Returns `true` when FineTune should expose AutoEQ correction controls for this device.
     /// HDMI, DisplayPort, AirPlay, virtual, and known speaker-only devices return `false`.
-    /// Built-in devices delegate to `builtInHasHeadphonesActive()` for headphone jack detection.
+    /// Built-in audio is allowed so Mac speakers and built-in jack headphones can be corrected.
     func supportsAutoEQ() -> Bool {
         let transport = readTransportType()
 
@@ -75,7 +75,7 @@ extension AudioDeviceID {
         case .hdmi, .displayPort, .airPlay, .virtual:
             return false
         case .builtIn:
-            return builtInHasHeadphonesActive()
+            return true
         default:
             break
         }


### PR DESCRIPTION
A minor change to allow users to be able to import a parametric EQ file to EQ the MacBook built-in speakers. Tested on my MacBook Air to help improve the sound.

<img width="1012" height="906" alt="Screenshot 2026-06-15 at 00-07-16" src="https://github.com/user-attachments/assets/4e02334b-7346-43be-af56-66ba0c2fbfb7" />


