### PR TITLE
fix: External monitor goes blank at launch

### DIFF
--- a/FineTune/Audio/Engine/AudioEngine.swift
+++ b/FineTune/Audio/Engine/AudioEngine.swift
@@ -273,7 +273,12 @@ final class AudioEngine {
                     self?.deviceVolumeMonitor.refreshAfterDDCProbe()
                     self?.refreshAllTapOutputStates()
                 }
-                ddc.start()
+                // DDC probing writes to displays over I2C. Some USB-C→HDMI / DP
+                // adapters mishandle this and drop the video link. Gate behind a
+                // user setting (default on) so affected users can disable it.
+                if manager.appSettings.ddcVolumeControlEnabled {
+                    ddc.start()
+                }
                 #endif
 
                 // Start device volume monitor AFTER deviceMonitor.start() populates devices
@@ -807,6 +812,20 @@ final class AudioEngine {
             tap.updateLoudnessEqualization(settings)
         }
     }
+
+    #if !APP_STORE
+    /// Starts or stops DDC/CI monitor-volume probing at runtime when the user
+    /// toggles the setting. Stopping halts all I2C writes to displays — the fix
+    /// for adapters that blank the screen when probed. Starting requires a relaunch
+    /// to take full effect for displays that were skipped at launch.
+    func setDDCVolumeControlEnabled(_ enabled: Bool) {
+        if enabled {
+            ddcController.start()
+        } else {
+            ddcController.stop()
+        }
+    }
+    #endif
 
     /// Apply AutoEQ profile to all taps currently routed to the given device.
     private func applyAutoEQToTaps(for deviceUID: String) {

--- a/FineTune/Settings/SettingsManager.swift
+++ b/FineTune/Settings/SettingsManager.swift
@@ -40,6 +40,13 @@ nonisolated struct AppSettings: Codable, Equatable {
     var loudnessCompensationEnabled: Bool = false  // ISO 226:2023 equal-loudness contour compensation
     var loudnessEqualizationEnabled: Bool = false  // Real-time loudness equalization
 
+    // Monitor (DDC/CI) volume control
+    // When enabled, FineTune probes external displays over I2C (DDC/CI) so monitor
+    // speakers appear as volume-controllable outputs. Probing writes to the display's
+    // DDC bus; some USB-C→HDMI / DisplayPort adapters mishandle this and drop the
+    // video link (monitor goes dark). Disable to skip all DDC probing/writes.
+    var ddcVolumeControlEnabled: Bool = true
+
     // Media Keys & HUD
     var hudStyle: HUDStyle = .tahoe                // Visual style of the volume HUD
     var mediaKeyControlEnabled: Bool = true        // Intercept F10/F11/F12 to drive the default output device
@@ -72,6 +79,7 @@ nonisolated struct AppSettings: Codable, Equatable {
         showDeviceDisconnectAlerts = try c.decodeIfPresent(Bool.self, forKey: .showDeviceDisconnectAlerts) ?? true
         loudnessCompensationEnabled = try c.decodeIfPresent(Bool.self, forKey: .loudnessCompensationEnabled) ?? false
         loudnessEqualizationEnabled = try c.decodeIfPresent(Bool.self, forKey: .loudnessEqualizationEnabled) ?? false
+        ddcVolumeControlEnabled = try c.decodeIfPresent(Bool.self, forKey: .ddcVolumeControlEnabled) ?? true
         hudStyle = try c.decodeIfPresent(HUDStyle.self, forKey: .hudStyle) ?? .tahoe
         mediaKeyControlEnabled = try c.decodeIfPresent(Bool.self, forKey: .mediaKeyControlEnabled) ?? true
         volumeHotkeyStep = try c.decodeIfPresent(VolumeHotkeyStep.self, forKey: .volumeHotkeyStep) ?? .normal

--- a/FineTune/Views/Settings/Tabs/AudioTab.swift
+++ b/FineTune/Views/Settings/Tabs/AudioTab.swift
@@ -46,6 +46,11 @@ struct AudioTab: View {
         .onChange(of: settings.appSettings.loudnessEqualizationEnabled) { _, newValue in
             audioEngine.setLoudnessEqualizationEnabled(newValue)
         }
+        #if !APP_STORE
+        .onChange(of: settings.appSettings.ddcVolumeControlEnabled) { _, newValue in
+            audioEngine.setDDCVolumeControlEnabled(newValue)
+        }
+        #endif
     }
 
     // MARK: - Volume
@@ -88,6 +93,18 @@ struct AudioTab: View {
                     .controlSize(.small)
                     .labelsHidden()
             }
+            #if !APP_STORE
+            SettingsRowDivider()
+            SettingsRow(
+                "Monitor Volume Control (DDC)",
+                description: "Control monitor speaker volume over HDMI/DisplayPort. Disable if an external display goes dark when FineTune launches."
+            ) {
+                Toggle("", isOn: $settings.appSettings.ddcVolumeControlEnabled)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .labelsHidden()
+            }
+            #endif
             SettingsRowDivider()
             SettingsRow(
                 "System Sounds",


### PR DESCRIPTION
Addresses #279 

Reproduced with Macbook Air M3 with Asus external display (usb type-c - HDMI cable), FineTune: 1.8.0 (homebrew) 

Root cause:
On launch FineTune probes external displays over DDC/CI (I2C) so monitor speakers appear as volume-controllable audio outputs. The probe writes to the display's DDC bus. Some USB-C→HDMI / DisplayPort-Alt-Mode adapters mishandle DDC/CI writes and drop the video link → monitor goes dark. A link drop fires `didChangeScreenParametersNotification` → FineTune re-probes after 3s → writes again → monitor stays dark for the whole session. Quitting stops the probes, physically reconnecting the monitor renegotiates the link.

Fix:
Add a user setting `ddcVolumeControlEnabled` (default `true`, preserves existing behavior). When off, no DDC probing/writes happen → no blackout. Exposed as a toggle in Settings → Audio. Runtime toggle starts/stops probing immediately; relaunch recommended after disabling


🤖 Generated with [Claude Code](https://claude.com/claude-code)