### PR TITLE
fix(hud): show volume overlay in fullscreen apps

### DIFF
--- a/FineTune/Views/HUD/HUDWindowController.swift
+++ b/FineTune/Views/HUD/HUDWindowController.swift
@@ -74,10 +74,6 @@ final class HUDWindowController: MediaKeyHUDPresenting {
         showCallCount += 1
         showDidUpdatePanel = false
 
-        guard !isForegroundAppFullscreen() else {
-            logger.debug("Skipping HUD show: foreground app is fullscreen")
-            return
-        }
         guard !popupVisibility.isVisible else {
             logger.debug("Skipping HUD show: popup is visible")
             return


### PR DESCRIPTION
## Problem

Pressing the volume keys while an app is fullscreen (video, presentations, maximized or tiled windows) changes the volume but shows no HUD, so there's no way to see the level without leaving fullscreen. Reported in #261 and #289.

## Root cause

The HUD is skipped whenever the frontmost app's window covers the whole screen. That check trips for any screen-filling window, normal fullscreen video, and maximized windows included, so the overlay never appears. The panel is already set up to draw over fullscreen spaces, so dropping the skip lets it show like the native macOS volume HUD.

## Related PR(s)/Issue(s)

- Closes #261
- Closes #289
