### PR TITLE
fix(audio): add recreateTap fallback when dynamic device switch/update fails

### DIFF
--- a/FineTune/Audio/Engine/AudioEngine.swift
+++ b/FineTune/Audio/Engine/AudioEngine.swift
@@ -948,6 +948,8 @@ final class AudioEngine {
                     self.logger.debug("Switched \(app.name) to device: \(targetUID)")
                 } catch {
                     self.logger.error("Failed to switch device for \(app.name): \(error.localizedDescription)")
+                    self.logger.info("Falling back to recreateTap for \(app.name)")
+                    await self.recreateTap(for: app.id)
                 }
             }
         } else {
@@ -1183,6 +1185,8 @@ final class AudioEngine {
                         self.applyAutoEQToTap(existingTap)
                     } catch {
                         self.logger.error("Failed to re-route \(app.name) to \(deviceUID): \(error.localizedDescription)")
+                        self.logger.info("Falling back to recreateTap for \(app.name)")
+                        await self.recreateTap(for: app.id)
                     }
                 }
                 appliedPIDs.insert(app.id)
@@ -1328,6 +1332,8 @@ final class AudioEngine {
                     self.applyAutoEQToTap(tap)
                 } catch {
                     self.logger.error("Failed to switch \(app.name) to \(targetUID): \(error.localizedDescription)")
+                    self.logger.info("Falling back to recreateTap for \(app.name)")
+                    await self.recreateTap(for: app.id)
                 }
             }
         }
@@ -1408,6 +1414,8 @@ final class AudioEngine {
                         self.applyAutoEQToTap(tap)
                     } catch {
                         self.logger.error("Failed to switch \(tap.app.name) to fallback: \(error.localizedDescription)")
+                        self.logger.info("Falling back to recreateTap for \(tap.app.name)")
+                        await self.recreateTap(for: tap.app.id)
                     }
                 }
 
@@ -1421,6 +1429,8 @@ final class AudioEngine {
                         self.logger.debug("Removed \(deviceName) from \(tap.app.name) multi-device output")
                     } catch {
                         self.logger.error("Failed to update \(tap.app.name) devices: \(error.localizedDescription)")
+                        self.logger.info("Falling back to recreateTap for \(tap.app.name) (multi-mode)")
+                        await self.recreateTap(for: tap.app.id, overridingDeviceUIDs: remainingUIDs)
                     }
                 }
             }
@@ -1480,6 +1490,8 @@ final class AudioEngine {
                         self.applyAutoEQToTap(tap)
                     } catch {
                         self.logger.error("Failed to switch \(tap.app.name) back to \(deviceName): \(error.localizedDescription)")
+                        self.logger.info("Falling back to recreateTap for \(tap.app.name)")
+                        await self.recreateTap(for: tap.app.id)
                     }
                 }
             }
@@ -1941,9 +1953,9 @@ final class AudioEngine {
     /// Tears down and recreates a tap for a given PID, preserving routing and settings.
     /// Async: awaits full CoreAudio resource teardown before creating the replacement tap
     /// to prevent orphaned IO procs from accumulating (issue #176).
-    private func recreateTap(for pid: pid_t) async {
+    private func recreateTap(for pid: pid_t, overridingDeviceUIDs: [String]? = nil) async {
         guard let oldTap = taps.removeValue(forKey: pid) else { return }
-        let deviceUIDs = oldTap.currentDeviceUIDs
+        let deviceUIDs = overridingDeviceUIDs ?? oldTap.currentDeviceUIDs
         await oldTap.invalidateAsync()
 
         // Set cooldown to prevent thrashing


### PR DESCRIPTION
## Summary

This PR introduces a robust error recovery mechanism for process tap routing switches and updates in `AudioEngine.swift`. 

Currently, if the underlying CoreAudio/HAL switch fails dynamically (e.g. during rapid device connections, sample rate changes, or Bluetooth state transitions), the error is caught and logged, but the process tap remains in an invalid state. This can lead to audio dropouts or silence for the affected application.

With this change, the engine falls back to calling `recreateTap(for:)` when any dynamic device switch or aggregate update fails. This tears down the invalid tap and recreates a fresh one, safely recovering the audio capture session and preventing permanent silence.

## Key Changes

### 1. Robust Fallback in Switch Actions
* Added `recreateTap` recovery to the `catch` blocks in:
  * `setDevice(for:deviceUID:)` — when explicit routing switch fails.
  * `applyPersistedSettings()` — when re-routing an existing tap on startup/settings updates fails.
  * `routeFollowsDefaultApps(to:)` — when switching follows-default apps to the new default output fails.
  * `handleDeviceDisconnected(_:name:)` — when moving a single-mode or multi-mode tap to its fallback/remaining devices fails.
  * `handleDeviceConnected(_:name:)` — when switching pinned apps back to their preferred device fails.

### 2. Multi-device Target Override Support
* Extended `recreateTap(for:overridingDeviceUIDs:)` signature to accept an optional array of device UIDs.
* If provided, the tap is recreated targetting this subset of devices instead of the old tap's full device list. This is utilized during multi-mode device disconnections when a subset of devices remains active.

---

## Verification

### Automated Tests
* Verified that the project builds clean and the entire unit test suite (`FineTuneTests`) passes successfully on the branch:
  ```bash
  xcodebuild test -project FineTune.xcodeproj -scheme FineTune -destination 'platform=macOS' -only-testing:FineTuneTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
  ```
* Output: `** TEST SUCCEEDED **`
