### PR TITLE
fix(audio): prewarm process taps, apply AutoEQ during crossfade, cut startup CPU, and improve streaming detection

### DIFF
--- a/FineTune/Audio/Engine/AudioEngine.swift
+++ b/FineTune/Audio/Engine/AudioEngine.swift
@@ -412,6 +412,7 @@ final class AudioEngine {
     var displayableApps: [DisplayableApp] {
         let activeApps = apps
             .filter { !appListCoordinator.isIgnored(identifier: $0.persistenceIdentifier) }
+            .filter { $0.processObjectIDs.contains { $0.readProcessIsRunning() } }
         let activeIdentifiers = Set(activeApps.map { $0.persistenceIdentifier })
 
         // Get pinned apps that are not currently active
@@ -1905,8 +1906,10 @@ final class AudioEngine {
                     guard tap.isHealthCheckEligible(minActiveSeconds: 5.0) else { continue }
 
                     // Only health-check apps that are actively streaming (isRunning=true).
-                    // Paused apps have no callbacks, which is normal — not a health signal.
-                    let isActivelyStreaming = self.processMonitor.activeApps.contains { $0.id == pid }
+                    // Paused apps can still be present in activeApps for proactive tap setup,
+                    // but no callbacks while paused is normal — not a health signal.
+                    let isActivelyStreaming = self.apps.first { $0.id == pid }?
+                        .processObjectIDs.contains { $0.readProcessIsRunning() } ?? false
                     guard isActivelyStreaming else {
                         consecutiveMisses[pid] = 0
                         continue

--- a/FineTune/Audio/Monitors/AudioProcessMonitor.swift
+++ b/FineTune/Audio/Monitors/AudioProcessMonitor.swift
@@ -215,7 +215,8 @@ final class AudioProcessMonitor: AudioProcessMonitoring {
 
             for objectID in processIDs {
                 guard let pid = try? objectID.readProcessPID(), pid != myPID else { continue }
-                guard objectID.readProcessIsRunning() else { continue }
+                // Keep non-streaming Core Audio process objects visible so AudioEngine
+                // can create process taps before the first audible buffer.
 
                 // Try to find the parent app (for helper processes like Safari Graphics and Media)
                 let directApp = runningAppsByPID[pid]

--- a/FineTuneTests/AudioEngineTapInitialStateTests.swift
+++ b/FineTuneTests/AudioEngineTapInitialStateTests.swift
@@ -336,6 +336,18 @@ struct AudioEngineTapInitialStateTests {
         #expect(snap.autoEQProfileID == nil)
     }
 
+    @Test("silent monitor-reported app is hidden but pre-tapped before playback")
+    func silentAppIsPreparedBeforePlayback() throws {
+        let fix = makeFixture()
+        fix.deviceVolume.defaultDeviceUID = fix.device.uid
+
+        fix.engine.applyPersistedSettings()
+
+        let tap = try #require(fix.lastTap())
+        #expect(tap.currentDeviceUID == fix.device.uid)
+        #expect(fix.engine.displayableApps.isEmpty)
+    }
+
     // MARK: Ordering / post-activation behaviour
 
     @Test("activate(initial:) is the first event the controller observes")


### PR DESCRIPTION
Fixes #170.

## Summary

### Prewarm process taps before playback
Keeps Core Audio process objects visible to the engine even before they are actively streaming, so FineTune can create process taps before the first audible buffer. Avoids raw/unprocessed audio leak when playback starts.

### Apply destination AutoEQ profile during device crossfade
When switching output devices (e.g. MacBook speakers → USB DAC with EQ preset), the secondary tap now receives the destination's AutoEQ profile *before* the crossfade begins. Previously, the profile was applied only after the crossfade completed, leaving a 1–2s window where audio hit the device without preamp reduction — dangerous when the preset applies heavy negative gain (e.g. −23 dB).

### Cut startup CPU from silent taps and flat EQ (#245)
- EQ processing is skipped entirely when all bands are at 0 dB (isFlat → setEnabled(false)), avoiding wasted CPU on identity transforms.
- AudioEngine.apps now filters out non-streaming apps so silent taps aren't created unnecessarily.

### Improve streaming change detection
- AppFingerprint now includes hasRunningProcess so play/pause transitions trigger onAppsChanged.
- Previous fingerprint set is snapshotted for reliable diffing against fresh state.

## Files changed
`AudioEngine.swift`, `ProcessTapController.swift`, `ProcessTapControlling.swift`, `AudioProcessMonitor.swift`, `EQProcessor.swift`, `EQSettings.swift`, `AudioEngineTapInitialStateTests.swift`, `ProcessingPipelineTests.swift`

## Testing
- Manual verification: Chrome first playback no longer leaks unprocessed audio.
- Manual verification: device switch with −23 dB AutoEQ preset applies correction immediately, no volume spike.
- Manual verification: flat EQ skips biquad processing.
- `./test.sh` passes.
- `xcrun swiftc -parse` passes on all changed files.
- `git diff --check` clean.