### PR TITLE
DDC: stop crash on volume change with DDC output

### DIFF
--- a/FineTune/Audio/DDC/DDCController.swift
+++ b/FineTune/Audio/DDC/DDCController.swift
@@ -81,14 +81,16 @@ final class DDCController {
             settingsManager.setDDCVolume(for: uid, to: clamped)
         }
 
-        // Debounce DDC write
+        // Keep the work item @Sendable and avoid `self`; otherwise it inherits
+        // @MainActor isolation here and traps when run on `ddcQueue`.
         debounceTimers[deviceID]?.cancel()
         let service = services[deviceID]
-        let item = DispatchWorkItem { [weak self] in
+        let logger = self.logger
+        let item = DispatchWorkItem { @Sendable in
             do {
                 try service?.setAudioVolume(clamped)
             } catch {
-                self?.logger.error("DDC write failed for device \(deviceID): \(error)")
+                logger.error("DDC write failed for device \(deviceID): \(error)")
             }
         }
         debounceTimers[deviceID] = item


### PR DESCRIPTION
Probably fixes https://github.com/ronitsingh10/FineTune/issues/348; in any case fixes a crash I was encountering locally.

Diagnosed with Claude 4.8

---

Root cause: the v1.8.0 migration to Swift 6 language mode gave the debounced DDC-write closure inherited `@MainActor` isolation; the runtime executor check traps when it runs on `ddcQueue`. Any volume change on a DDC-controlled monitor crashes the app.

Fixes #340, fixes #348, fixes #353, fixes #356