### PR TITLE
DDC: send VCP writes twice

### DIFF
--- a/FineTune/Audio/DDC/DDCService.swift
+++ b/FineTune/Audio/DDC/DDCService.swift
@@ -137,16 +137,18 @@ final class DDCService: @unchecked Sendable {
     }
 
     /// Writes a DDC packet without reading a response.
+    ///
+    /// Send all write cycles; some displays only apply the second write.
     private func i2cWrite(packet: [UInt8]) throws {
+        var lastResult: IOReturn = kIOReturnError
         for _ in 0..<numWriteCycles {
             usleep(writeSleepTime)
-            let result = packet.withUnsafeBufferPointer { buf in
+            lastResult = packet.withUnsafeBufferPointer { buf in
                 IOAVServiceLoader.writeI2C(service: service, chipAddress: chipAddress,
                                            dataAddress: writeAddress, buffer: buf.baseAddress!, size: UInt32(buf.count))
             }
-            if result == kIOReturnSuccess { return }
         }
-        throw DDCError.writeFailed(kIOReturnError)
+        guard lastResult == kIOReturnSuccess else { throw DDCError.writeFailed(lastResult) }
     }
 
     // MARK: - VCP Commands


### PR DESCRIPTION
As done in MonitorControl; send VCP writes twice such that they stick.

Verified against a Dell U4021QW via a standalone IOAVService harness: one write leaves VCP 0x62 unchanged; two writes change it as expected.

Developed with Claude 4.8