### PR TITLE
Fix a batch of low-hanging-fruit bugs from the issue tracker

### DIFF
--- a/FineTune/Audio/DDC/DDCController.swift
+++ b/FineTune/Audio/DDC/DDCController.swift
@@ -286,10 +286,17 @@ final class DDCController {
                 for (deviceID, uid) in matchedUIDsSnapshot {
                     if let savedVolume = self.settingsManager.getDDCVolume(for: uid) {
                         self.cachedVolumes[deviceID] = savedVolume
-                        // Restore saved volume to the display
-                        let service = matchedSnapshot[deviceID]
-                        self.ddcQueue.async {
-                            try? service?.setAudioVolume(savedVolume)
+                        // Restore saved volume to the display — but never when the
+                        // user pinned a non-DDC backend for this device: a Set VCP
+                        // write pops the monitor's volume OSD on every probe (app
+                        // launch, display reconnect). Matching stays untouched so
+                        // isDDCBacked and the "Auto: DDC" badge remain accurate.
+                        let override = self.settingsManager.getDeviceVolumeTierOverride(for: uid)
+                        if override == nil || override == .ddc {
+                            let service = matchedSnapshot[deviceID]
+                            self.ddcQueue.async {
+                                try? service?.setAudioVolume(savedVolume)
+                            }
                         }
                     } else if let readVolume = volumesSnapshot[deviceID] {
                         self.cachedVolumes[deviceID] = readVolume

--- a/FineTune/Audio/Engine/AudioEngine.swift
+++ b/FineTune/Audio/Engine/AudioEngine.swift
@@ -350,6 +350,7 @@ final class AudioEngine {
         }
 
         processMonitor.onAppsChanged = { [weak self] apps in
+            self?.reconcileTapProcessObjects(with: apps)
             self?.applyPersistedSettings()
             self?.scheduleStaleCleanup()
         }
@@ -1936,6 +1937,34 @@ final class AudioEngine {
     private func stopHealthMonitor() {
         healthMonitorTask?.cancel()
         healthMonitorTask = nil
+    }
+
+    /// PIDs with a process-object-growth recreate in flight (prevents duplicate recreates
+    /// when onAppsChanged fires again before the async recreate finishes).
+    private var reconcilingPIDs: Set<pid_t> = []
+
+    /// Recreates the tap for any app whose CoreAudio process-object set gained members
+    /// after the tap was created. The tap description is a snapshot: `.mutedWhenTapped`
+    /// mutes only the objects listed in it, so an audio client that appears later (e.g.
+    /// Spotify spinning up its video pipeline in a helper process) is neither captured
+    /// nor muted — it plays raw at full device volume, bypassing per-app gain and EQ.
+    /// Shrinks are deliberately ignored: process objects flicker out on every pause
+    /// (the isRunning filter) and stale entries in a live tap description are harmless.
+    private func reconcileTapProcessObjects(with apps: [AudioApp]) {
+        for app in apps {
+            guard let tap = taps[app.id] else { continue }
+            // PID-reuse guard — same pattern as stale-tap cleanup.
+            guard tap.app.bundleID == app.bundleID else { continue }
+            guard !reconcilingPIDs.contains(app.id) else { continue }
+            let added = Set(app.processObjectIDs).subtracting(tap.app.processObjectIDs)
+            guard !added.isEmpty else { continue }
+            logger.info("Process objects grew for \(app.name, privacy: .public) (+\(added.count)) — recreating tap to capture the new audio client")
+            reconcilingPIDs.insert(app.id)
+            Task {
+                await self.recreateTap(for: app.id)
+                self.reconcilingPIDs.remove(app.id)
+            }
+        }
     }
 
     /// Tears down and recreates a tap for a given PID, preserving routing and settings.

--- a/FineTune/Audio/Keys/MediaKeyMonitor.swift
+++ b/FineTune/Audio/Keys/MediaKeyMonitor.swift
@@ -240,6 +240,7 @@ final class MediaKeyMonitor {
             currentMute: volumeMonitor.muteStates[deviceID] ?? false,
             setVolume: { id, vol in volumeMonitor.setVolume(for: id, to: vol) },
             setMute:   { id, mute in volumeMonitor.setMute(for: id, to: mute) },
+            getVolume: { id in volumeMonitor.volumes[id] ?? 0 },
             playFeedback: { gain in
                 self.feedbackPlayer?.requestFeedback(
                     gain: gain,
@@ -262,6 +263,7 @@ final class MediaKeyMonitor {
         currentMute: Bool,
         setVolume: (AudioDeviceID, Float) -> Void,
         setMute: (AudioDeviceID, Bool) -> Void,
+        getVolume: ((AudioDeviceID) -> Float)? = nil,
         playFeedback: (Float) -> Void = { _ in }
     ) {
         let shouldShowHUD = !popupVisibility.isVisible
@@ -312,7 +314,16 @@ final class MediaKeyMonitor {
             let newMute = !currentMute
             setMute(deviceID, newMute)
             if shouldShowHUD {
-                hudController.show(sliderFraction: currentSlider, mute: newMute, deviceName: deviceName)
+                // Software-tier mute zeroes the visible volume and unmute restores
+                // the saved level inside setMute, so the pre-toggle snapshot reads
+                // 0% after unmuting — re-read to show the restored level.
+                let slider: Double
+                if !newMute, let getVolume {
+                    slider = VolumeMapping.sliderFraction(forSystemGain: getVolume(deviceID), tier: tier)
+                } else {
+                    slider = currentSlider
+                }
+                hudController.show(sliderFraction: slider, mute: newMute, deviceName: deviceName)
             }
             iconCoordinator?.flashDevice()
         }

--- a/FineTune/FineTuneApp.swift
+++ b/FineTune/FineTuneApp.swift
@@ -171,6 +171,10 @@ struct FineTuneApp: App {
         DispatchQueue.main.async { [coordinator] in coordinator.start() }
         _iconCoordinator = State(initialValue: coordinator)
 
+        // Correct a FluidMenuBarExtra cold-launch mispositioning race on some
+        // multi-monitor setups (see MenuBarPanelPositionFixup doc comment / GH #387).
+        DispatchQueue.main.async { MenuBarPanelPositionFixup.run() }
+
         // Render the scene's first frame with the user's chosen style instead of a generic
         // placeholder, so non-speaker styles don't briefly flash a speaker icon at launch.
         let launchVolumeMonitor = engine.deviceVolumeMonitor

--- a/FineTune/Settings/SettingsManager.swift
+++ b/FineTune/Settings/SettingsManager.swift
@@ -33,6 +33,9 @@ nonisolated struct AppSettings: Codable, Equatable {
     // Input Device Lock
     var lockInputDevice: Bool = true          // Prevent auto-switching input device
 
+    // Output Device Auto-Switch
+    var autoSwitchToNewOutputDevices: Bool = true  // Make a newly-seen output device the default automatically
+
     // Notifications
     var showDeviceDisconnectAlerts: Bool = true
 
@@ -69,6 +72,7 @@ nonisolated struct AppSettings: Codable, Equatable {
         menuBarIconStyle = try c.decodeIfPresent(MenuBarIconStyle.self, forKey: .menuBarIconStyle) ?? .default
         defaultNewAppVolume = try c.decodeIfPresent(Float.self, forKey: .defaultNewAppVolume) ?? 1.0
         lockInputDevice = try c.decodeIfPresent(Bool.self, forKey: .lockInputDevice) ?? true
+        autoSwitchToNewOutputDevices = try c.decodeIfPresent(Bool.self, forKey: .autoSwitchToNewOutputDevices) ?? true
         showDeviceDisconnectAlerts = try c.decodeIfPresent(Bool.self, forKey: .showDeviceDisconnectAlerts) ?? true
         loudnessCompensationEnabled = try c.decodeIfPresent(Bool.self, forKey: .loudnessCompensationEnabled) ?? false
         loudnessEqualizationEnabled = try c.decodeIfPresent(Bool.self, forKey: .loudnessEqualizationEnabled) ?? false
@@ -483,7 +487,15 @@ final class SettingsManager {
 
     func ensureDeviceInPriority(_ uid: String) {
         guard !settings.outputDevicePriority.contains(uid) else { return }
-        settings.outputDevicePriority.append(uid)
+        // Auto-switch mode: a device we've never seen before goes to the front of the
+        // priority list, so AudioEngine's existing "connected + highest priority" check
+        // makes it the default. Otherwise new devices are lowest priority, matching prior
+        // behavior — the user picks it explicitly rather than being switched involuntarily.
+        if settings.appSettings.autoSwitchToNewOutputDevices {
+            settings.outputDevicePriority.insert(uid, at: 0)
+        } else {
+            settings.outputDevicePriority.append(uid)
+        }
         scheduleSave()
     }
 

--- a/FineTune/Shortcuts/FluidMenuBarExtraIntrospection.swift
+++ b/FineTune/Shortcuts/FluidMenuBarExtraIntrospection.swift
@@ -1,0 +1,50 @@
+// FineTune/Shortcuts/FluidMenuBarExtraIntrospection.swift
+import AppKit
+
+/// Shared `NSApp.windows` + KVC introspection helpers for locating FineTune's
+/// `FluidMenuBarExtra`-backed status item and panel from outside the SwiftUI
+/// scene chain. See `MenuBarPopupController`'s doc comment for why this
+/// technique is safe and package-agnostic.
+@MainActor
+enum FluidMenuBarExtraIntrospection {
+    /// macOS renamed the concrete `NSStatusItem` runtime class in the macOS 26
+    /// scene-based status item refactor. Keep both branches so we work across
+    /// the deployment-target floor (14.2) up through current 26.x.
+    static var concreteStatusItemClassName: String {
+        if #available(macOS 26.0, *) {
+            return "NSSceneStatusItem"
+        }
+        return "NSStatusItem"
+    }
+
+    static func findStatusItem(accessibilityTitle: String) -> NSStatusItem? {
+        let concreteName = concreteStatusItemClassName
+
+        return NSApp.windows
+            .filter { $0.className.contains("NSStatusBarWindow") }
+            .compactMap(extractStatusItem(from:))
+            // Multi-display setups with "Displays have separate Spaces" enabled produce
+            // one NSStatusBarWindow per display; the inactive ones return an
+            // `NSStatusItemReplicant` (a subclass of NSStatusItem). Skip replicants —
+            // we only want the canonical item that owns the real button.
+            .filter { $0.className == concreteName }
+            .first { $0.button?.accessibilityTitle() == accessibilityTitle }
+    }
+
+    /// Locates the `FluidMenuBarExtraWindow` panel among `NSApp.windows`. The
+    /// type itself isn't `public` in the FluidMenuBarExtra module, so we match
+    /// by class name rather than importing/casting to the concrete type.
+    static func findPanel() -> NSPanel? {
+        NSApp.windows.first { $0.className.contains("FluidMenuBarExtraWindow") } as? NSPanel
+    }
+
+    /// Pulls the `statusItem` private key off an `NSStatusBarWindow`.
+    /// KVC is the primary path; `Mirror` is a defensive fallback in case Apple
+    /// changes how the property is exposed in a future macOS release.
+    private static func extractStatusItem(from window: NSWindow) -> NSStatusItem? {
+        if let item = window.value(forKey: "statusItem") as? NSStatusItem {
+            return item
+        }
+        return Mirror(reflecting: window).descendant("statusItem") as? NSStatusItem
+    }
+}

--- a/FineTune/Shortcuts/MenuBarPanelPositionFixup.swift
+++ b/FineTune/Shortcuts/MenuBarPanelPositionFixup.swift
@@ -1,0 +1,83 @@
+// FineTune/Shortcuts/MenuBarPanelPositionFixup.swift
+import AppKit
+import os
+
+/// Works around a `FluidMenuBarExtra` cold-launch race (GitHub #387): on some
+/// multi-monitor / unusual-DPI setups, the package's very first internal
+/// frame calculation for the menu-bar panel runs before AppKit has finished
+/// assigning the status item's button window to its correct screen. The
+/// panel's origin is then computed from an effectively-zero anchor frame and
+/// lands at the screen's bottom-left corner instead of below the icon.
+///
+/// User-reported workarounds (drag the icon, or open the panel once on
+/// another display first) all share one thing: they force a second internal
+/// reposition pass after the status item's window has settled. This polls
+/// for that settled state, then re-applies the correct frame to the panel
+/// directly — reimplementing FluidMenuBarExtra's own "below the icon,
+/// left-aligned, clamped to visibleFrame" placement, since the types and
+/// methods that actually own that logic aren't public API.
+@MainActor
+enum MenuBarPanelPositionFixup {
+    private static let logger = Logger(
+        subsystem: "com.finetuneapp.FineTune",
+        category: "MenuBarPanelPositionFixup"
+    )
+
+    private static let maxAttempts = 20
+    private static let pollInterval: TimeInterval = 0.1
+
+    /// Starts polling for a settled status item + panel, then corrects the
+    /// panel's frame once. Safe to call once at launch; a no-op fixup (frame
+    /// already correct) is cheap and logs nothing.
+    static func run(accessibilityTitle: String = "FineTune", attempt: Int = 0) {
+        guard let statusItem = FluidMenuBarExtraIntrospection.findStatusItem(accessibilityTitle: accessibilityTitle),
+              let button = statusItem.button,
+              let anchorWindow = button.window else {
+            retryOrGiveUp(accessibilityTitle: accessibilityTitle, attempt: attempt)
+            return
+        }
+
+        let anchorFrame = anchorWindow.frame
+        guard let screen = anchorWindow.screen, !anchorFrame.isEmpty else {
+            retryOrGiveUp(accessibilityTitle: accessibilityTitle, attempt: attempt)
+            return
+        }
+
+        guard let panel = FluidMenuBarExtraIntrospection.findPanel(), !panel.frame.isEmpty else {
+            retryOrGiveUp(accessibilityTitle: accessibilityTitle, attempt: attempt)
+            return
+        }
+
+        var correctedFrame = CGRect(origin: anchorFrame.origin, size: panel.frame.size)
+        correctedFrame.origin.y -= correctedFrame.height
+
+        if correctedFrame.maxX > screen.visibleFrame.maxX {
+            correctedFrame.origin.x = screen.visibleFrame.maxX - correctedFrame.width
+        }
+        if correctedFrame.minX < screen.visibleFrame.minX {
+            correctedFrame.origin.x = screen.visibleFrame.minX
+        }
+
+        // Only touch the panel if it's meaningfully off — avoids fighting a
+        // frame FluidMenuBarExtra already positioned correctly, and avoids
+        // nudging a panel the user has since dragged (if that ever becomes
+        // possible) or is mid-open.
+        guard abs(correctedFrame.origin.x - panel.frame.origin.x) > 1 ||
+              abs(correctedFrame.origin.y - panel.frame.origin.y) > 1 else {
+            return
+        }
+
+        logger.debug("Correcting cold-launch panel frame from \(panel.frame.debugDescription, privacy: .public) to \(correctedFrame.debugDescription, privacy: .public)")
+        panel.setFrame(correctedFrame, display: panel.isVisible, animate: false)
+    }
+
+    private static func retryOrGiveUp(accessibilityTitle: String, attempt: Int) {
+        guard attempt < maxAttempts else {
+            logger.debug("Giving up after \(maxAttempts, privacy: .public) attempts; status item/panel never settled")
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + pollInterval) {
+            run(accessibilityTitle: accessibilityTitle, attempt: attempt + 1)
+        }
+    }
+}

--- a/FineTune/Shortcuts/MenuBarPopupController.swift
+++ b/FineTune/Shortcuts/MenuBarPopupController.swift
@@ -76,39 +76,9 @@ final class MenuBarPopupController: MenuBarPopupControlling {
 
     // MARK: - NSApp.windows + KVC introspection
 
-    /// macOS renamed the concrete `NSStatusItem` runtime class in the macOS 26
-    /// scene-based status item refactor. Keep both branches so we work across
-    /// the deployment-target floor (14.2) up through current 26.x.
-    private static var concreteStatusItemClassName: String {
-        if #available(macOS 26.0, *) {
-            return "NSSceneStatusItem"
-        }
-        return "NSStatusItem"
-    }
-
     /// Exposed `internal` so tests can verify discovery without depending on
     /// `NSApp.postEvent` delivery, which is flaky in a unit-test process.
     func findStatusItem() -> NSStatusItem? {
-        let concreteName = Self.concreteStatusItemClassName
-
-        return NSApp.windows
-            .filter { $0.className.contains("NSStatusBarWindow") }
-            .compactMap(Self.extractStatusItem(from:))
-            // Multi-display setups with "Displays have separate Spaces" enabled produce
-            // one NSStatusBarWindow per display; the inactive ones return an
-            // `NSStatusItemReplicant` (a subclass of NSStatusItem). Skip replicants —
-            // we only want the canonical item that owns the real button.
-            .filter { $0.className == concreteName }
-            .first { $0.button?.accessibilityTitle() == accessibilityTitle }
-    }
-
-    /// Pulls the `statusItem` private key off an `NSStatusBarWindow`.
-    /// KVC is the primary path; `Mirror` is a defensive fallback in case Apple
-    /// changes how the property is exposed in a future macOS release.
-    private static func extractStatusItem(from window: NSWindow) -> NSStatusItem? {
-        if let item = window.value(forKey: "statusItem") as? NSStatusItem {
-            return item
-        }
-        return Mirror(reflecting: window).descendant("statusItem") as? NSStatusItem
+        FluidMenuBarExtraIntrospection.findStatusItem(accessibilityTitle: accessibilityTitle)
     }
 }

--- a/FineTune/Views/Components/EditablePercentage.swift
+++ b/FineTune/Views/Components/EditablePercentage.swift
@@ -130,7 +130,9 @@ struct EditablePercentage: View {
         coordinator.install(
             excludingFrame: componentFrame,
             onClickOutside: { [self] in
-                cancel()
+                // Losing focus by clicking elsewhere should behave like Return, not
+                // Escape — otherwise a typed value silently reverts (issue #358).
+                commit()
             }
         )
 

--- a/FineTune/Views/Components/PopoverHost.swift
+++ b/FineTune/Views/Components/PopoverHost.swift
@@ -64,6 +64,46 @@ struct PopoverHost<Content: View>: NSViewRepresentable {
         var globalEventMonitor: Any?
         var appDeactivateObserver: NSObjectProtocol?
         weak var parentWindow: NSWindow?
+        /// Trigger button frame in screen coordinates, captured once when the
+        /// panel opens. Reused to keep the panel anchored to the trigger when
+        /// repositioning after a content resize.
+        var triggerFrame: NSRect = .zero
+
+        /// Computes a panel origin anchored below `triggerFrame`, flipping above
+        /// the trigger and/or clamping to the screen's `visibleFrame` so the
+        /// panel never renders off-screen (partially or fully) on any monitor,
+        /// including multi-monitor/ultrawide setups.
+        private func clampedOrigin(triggerFrame: NSRect, panelSize: NSSize) -> NSPoint {
+            let screen = NSScreen.screens.first {
+                $0.frame.contains(NSPoint(x: triggerFrame.midX, y: triggerFrame.midY))
+            } ?? NSScreen.main
+
+            guard let visibleFrame = screen?.visibleFrame else {
+                return NSPoint(x: triggerFrame.origin.x, y: triggerFrame.origin.y - panelSize.height - 4)
+            }
+
+            var x = triggerFrame.origin.x
+            var y = triggerFrame.origin.y - panelSize.height - 4
+
+            // Not enough room below the trigger: try flipping above it.
+            if y < visibleFrame.minY {
+                let aboveY = triggerFrame.maxY + 4
+                if aboveY + panelSize.height <= visibleFrame.maxY {
+                    y = aboveY
+                } else {
+                    y = visibleFrame.minY
+                }
+            }
+
+            if x + panelSize.width > visibleFrame.maxX {
+                x = visibleFrame.maxX - panelSize.width
+            }
+            if x < visibleFrame.minX {
+                x = visibleFrame.minX
+            }
+
+            return NSPoint(x: x, y: y)
+        }
 
         init(isPresented: Binding<Bool>) {
             self._isPresented = isPresented
@@ -104,14 +144,10 @@ struct PopoverHost<Content: View>: NSViewRepresentable {
             panel.setContentSize(hosting.fittingSize)
             self.hostingView = hosting
 
-            // Position below trigger
-            let parentFrame = parentView.convert(parentView.bounds, to: nil)
-            let screenFrame = parentWindow.convertToScreen(parentFrame)
-            let panelOrigin = NSPoint(
-                x: screenFrame.origin.x,
-                y: screenFrame.origin.y - panel.frame.height - 4
-            )
-            panel.setFrameOrigin(panelOrigin)
+            // Position below trigger, clamped to the trigger's screen bounds.
+            let screenFrame = parentWindow.convertToScreen(parentView.convert(parentView.bounds, to: nil))
+            self.triggerFrame = screenFrame
+            panel.setFrameOrigin(clampedOrigin(triggerFrame: screenFrame, panelSize: panel.frame.size))
 
             // Add as child window - links to parent's event stream
             parentWindow.addChildWindow(panel, ordered: .above)
@@ -126,15 +162,12 @@ struct PopoverHost<Content: View>: NSViewRepresentable {
 
             self.panel = panel
 
-            // Get trigger button frame in screen coordinates
-            let triggerFrame = parentWindow.convertToScreen(parentView.convert(parentView.bounds, to: nil))
-
             // Local monitor: clicks within our app (outside panel AND outside trigger)
             localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] event in
                 guard let self = self, let panel = self.panel else { return event }
                 let mouseLocation = NSEvent.mouseLocation
                 let isInPanel = panel.frame.contains(mouseLocation)
-                let isInTrigger = triggerFrame.contains(mouseLocation)
+                let isInTrigger = self.triggerFrame.contains(mouseLocation)
                 // Only dismiss if click is outside both panel and trigger button
                 // Let the trigger button handle its own clicks (toggle behavior)
                 if !isInPanel && !isInTrigger {
@@ -172,10 +205,13 @@ struct PopoverHost<Content: View>: NSViewRepresentable {
             // Update existing hosting view's rootView instead of replacing it
             // This allows SwiftUI to perform efficient diffing without flickering
             hostingView.rootView = AnyView(content().preferredColorScheme(preferredColorScheme))
-            // Resize panel if content size changed
+            // Resize panel if content size changed, then re-clamp the origin —
+            // otherwise a growing/shrinking panel can drift off-screen since
+            // `setContentSize` keeps the frame's bottom-left corner fixed.
             let newSize = hostingView.fittingSize
             if let panel = panel, panel.frame.size != newSize {
                 panel.setContentSize(newSize)
+                panel.setFrameOrigin(clampedOrigin(triggerFrame: triggerFrame, panelSize: panel.frame.size))
             }
         }
 

--- a/FineTune/Views/HUD/HUDWindowController.swift
+++ b/FineTune/Views/HUD/HUDWindowController.swift
@@ -301,7 +301,12 @@ final class HUDWindowController: MediaKeyHUDPresenting {
             backing: .buffered,
             defer: false
         )
-        p.level = .floating
+        // `.floating` is too low to be composited into a fullscreen app's dedicated
+        // Space — `.fullScreenAuxiliary` below only makes the window *eligible* to
+        // join that space, the level still gates whether it actually renders above
+        // the fullscreen content. `.screenSaver` matches what "always on top, even
+        // over fullscreen" overlay/HUD windows need (issues #261, #289).
+        p.level = .screenSaver
         p.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle, .transient]
         p.hasShadow = false
         p.isOpaque = false

--- a/FineTune/Views/Settings/Tabs/AudioTab.swift
+++ b/FineTune/Views/Settings/Tabs/AudioTab.swift
@@ -90,6 +90,16 @@ struct AudioTab: View {
             }
             SettingsRowDivider()
             SettingsRow(
+                "Switch to New Output Devices",
+                description: "Make a newly connected output device the default"
+            ) {
+                Toggle("", isOn: $settings.appSettings.autoSwitchToNewOutputDevices)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .labelsHidden()
+            }
+            SettingsRowDivider()
+            SettingsRow(
                 "System Sounds",
                 description: "Where alerts and effects play"
             ) {


### PR DESCRIPTION
## Summary

Works through a batch of low-hanging-fruit issues from the tracker — mostly isolated UI/logic bugs verified against the actual source before fixing, plus a couple of feature gaps closed with an opt-out toggle.

- **#399, #391, #338, #325** — per-app device picker / dropdown popups rendered off-screen near a display's edge or on multi-monitor setups. `PopoverHost` had no `NSScreen.visibleFrame` clamping at all; added clamping + re-clamp after content resize (fixes #325's "appears then drifts" symptom too).
- **#387** — main menu-bar panel opens at the wrong corner on cold launch on some multi-monitor/ultrawide setups. Root cause is inside the `FluidMenuBarExtra` dependency (filed upstream: wadetregaskis/FluidMenuBarExtra#3); worked around locally by polling for a settled status item and correcting the panel frame once.
- **#376** — HUD showed 0% right after unmuting a software-tier device (e.g. an external monitor without hardware volume) even though audio resumed at the correct level; the HUD read a pre-toggle volume snapshot instead of the post-unmute restored value.
- **#358** — typing a volume percentage then clicking away (instead of pressing Return) silently discarded the edit instead of committing it.
- **#374** — pinning a device's volume backend away from DDC didn't stop `DDCController`'s probe from re-writing the old saved DDC volume on every app launch/display reconnect, popping the monitor's own volume OSD and clobbering its hardware volume.
- **#373** — switching a Spotify track to its video variant went silent. A tap's `CATapDescription` snapshots an app's CoreAudio process objects at creation time; Spotify spins up a new client for video playback after the tap already exists, so that client was never captured. Added a reconcile step that recreates the tap when an already-tapped app's process-object set grows.
- **#261, #289** — the volume HUD never appeared during fullscreen video. The panel's window level (`.floating`) was too low to be composited into a fullscreen app's dedicated Space; raised to `.screenSaver`.
- **#411** — plugging in a new output device (audio interface, BT headphones) for the first time didn't switch to it. The auto-switch check in `AudioEngine` already existed but only fires for the *highest-priority* connected device, and new devices were always appended to the bottom of the priority list. Now inserted at the front by default (toggle in Settings > Audio > Devices to opt out).

Also verified **#319** is already fixed by an earlier keyboard-entry rewrite (`8c5b7fc`) — no change needed there.

## Not included

A few issues were investigated but deliberately left alone rather than landing a speculative fix:
- **#277** (keyboard volume step curve on software-tier devices) — traced the whole gain/slider conversion pipeline and it's self-consistent by design; couldn't reproduce the exact reported step sequence without the reporter's hardware.
- **#381** (duplicate-monitor-name volume cross-talk) — root cause identified (DDC device matching doesn't use the EDID serial number to disambiguate identical monitor models), but the correct fix depends on details of CoreAudio's UID encoding I can't verify without two identical monitors.
- **#281** (alert volume not proportional to system volume) — real gap, but it's architectural: system alert sounds bypass FineTune's audio tap entirely for software-tier output devices, so there's no signal to attenuate. Needs a design decision, not a quick patch.
- **#284, #292** (Multi-Output Device silence with Studio Display XDR; Discord/Teams/Meet double audio during screen share) — both need specific hardware/apps to reproduce safely.
- **#326, #316, #405, #274** (AirPods/BT auto-switch fighting FineTune's priority system) — all funnel into `AudioEngine`'s `PriorityState`/`EchoTracker` machinery, which already has significant BT-specific timing logic. Too central and timing-sensitive to patch blind without live hardware to observe the actual HAL event sequence.
- **#346** — already being addressed by open upstream PR #409.

## Test plan

- [x] `xcodebuild build` succeeds (Debug, unsigned) after every change
- [x] `MenuBarPopupControllerTests`, `MediaKeyMonitorHandlerTests`, `AudioEngineToggleMuteTests`, `AudioEngineTapInitialStateTests`, `SettingsManagerTests` all pass
- [ ] Manual verification on real multi-monitor/Bluetooth/DDC hardware would still be valuable for #387, #374, #373, #411 before release