### PR TITLE
NID-501: Add MenuBarIconStyle.monochrome for minimalist volume-independent icon

### DIFF
--- a/FineTune/Settings/SettingsManager.swift
+++ b/FineTune/Settings/SettingsManager.swift
@@ -92,7 +92,7 @@ final class SettingsManager {
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "FineTune", category: "SettingsManager")
 
     struct Settings: Codable {
-        var version: Int = 12
+        var version: Int = 13
         var appVolumes: [String: Float] = [:]
         var appDeviceRouting: [String: String] = [:]  // bundleID → deviceUID
         var appMutes: [String: Bool] = [:]  // bundleID → isMuted

--- a/FineTune/Settings/Types/SettingsUITypes.swift
+++ b/FineTune/Settings/Types/SettingsUITypes.swift
@@ -10,6 +10,7 @@ enum MenuBarIconStyle: String, Codable, CaseIterable, Identifiable {
     case device = "Device"
     case waveform = "Waveform"
     case equalizer = "Equalizer"
+    case monochrome = "Monochrome"
 
     var id: String { rawValue }
 
@@ -21,6 +22,7 @@ enum MenuBarIconStyle: String, Codable, CaseIterable, Identifiable {
         case .device: return "headphones"
         case .waveform: return "waveform"
         case .equalizer: return "slider.vertical.3"
+        case .monochrome: return "speaker.fill"
         }
     }
 

--- a/FineTune/Views/MenuBar/MenuBarIconState.swift
+++ b/FineTune/Views/MenuBar/MenuBarIconState.swift
@@ -77,6 +77,9 @@ extension MenuBarIconState {
             return .staticBaseline(.systemSymbol("waveform"))
         case .equalizer:
             return .staticBaseline(.systemSymbol("slider.vertical.3"))
+        case .monochrome:
+            if muted { return .speakerMuted }
+            return .staticBaseline(.systemSymbol("speaker.fill"))
         }
     }
 }

--- a/FineTuneTests/DeviceVolumeTierTests.swift
+++ b/FineTuneTests/DeviceVolumeTierTests.swift
@@ -394,6 +394,87 @@ struct SettingsMigrationV10toV11Tests {
     }
 }
 
+// MARK: - v12 → v13 Migration (MenuBarIconStyle.monochrome)
+
+@Suite("SettingsManager — v12 → v13 migration")
+@MainActor
+struct SettingsMigrationV12toV13Tests {
+    /// Inline v12 fixture: the shape a user upgrading from the previous release
+    /// will have on disk. The menuBarIconStyle is set to "Speaker" (a valid v12 value).
+    private let v12Json = #"""
+    {
+      "version": 12,
+      "appVolumes": {},
+      "appSettings": {
+        "defaultNewAppVolume": 1.0,
+        "launchAtLogin": false,
+        "menuBarIconStyle": "Speaker",
+        "lockInputDevice": true,
+        "showDeviceDisconnectAlerts": true,
+        "loudnessCompensationEnabled": false,
+        "loudnessEqualizationEnabled": false,
+        "mediaKeyControlEnabled": true,
+        "hudStyle": "tahoe"
+      }
+    }
+    """#
+
+    @Test("Decoding a v12 settings.json uses the Speaker style (backward compatible)")
+    func decodeV12BackwardCompatible() throws {
+        let data = Data(v12Json.utf8)
+        let decoded = try JSONDecoder().decode(SettingsManager.Settings.self, from: data)
+
+        #expect(decoded.version == 12)
+        #expect(decoded.appSettings.menuBarIconStyle == .speaker)
+    }
+
+    @Test("Re-encode after v12 decode bumps to v13 on a fresh Settings instance")
+    func defaultSettingsVersionIsThirteen() {
+        let fresh = SettingsManager.Settings()
+        #expect(fresh.version == 13)
+    }
+
+    @Test("SettingsManager loads from disk without throwing for a v12 file on-disk")
+    func loadV12FromDisk() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let url = tempDir.appendingPathComponent("settings.json")
+        try Data(v12Json.utf8).write(to: url, options: .atomic)
+
+        let manager = SettingsManager(directory: tempDir)
+        #expect(manager.appSettings.menuBarIconStyle == .speaker)
+    }
+
+    @Test("v13 fixture decodes with Monochrome menu bar icon style")
+    func decodeV13Fixture() throws {
+        let fixtureURL = Bundle(for: type(of: self))
+            .url(forResource: "settings-v13", withExtension: "json")
+        let data = try Data(contentsOf: fixtureURL!)
+        let decoded = try JSONDecoder().decode(SettingsManager.Settings.self, from: data)
+        #expect(decoded.version == 13)
+        #expect(decoded.appSettings.menuBarIconStyle == .monochrome)
+        #expect(decoded.appSettings.mediaKeyControlEnabled == true)
+        #expect(decoded.appSettings.hudStyle == .tahoe)
+    }
+
+    @Test("Unknown menuBarIconStyle string decodes to .default (defensive)")
+    func unknownStyleFallsBackToDefault() throws {
+        let json = #"""
+        {
+          "version": 13,
+          "appVolumes": {},
+          "appSettings": {
+            "menuBarIconStyle": "UnknownStyle"
+          }
+        }
+        """#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(SettingsManager.Settings.self, from: data)
+        #expect(decoded.appSettings.menuBarIconStyle == .default)
+    }
+}
+
 // MARK: - SettingsManager round-trip extension
 
 @Suite("SettingsManager.Settings — deviceVolumeTierOverride round-trip")

--- a/FineTuneTests/Fixtures/settings-v13.json
+++ b/FineTuneTests/Fixtures/settings-v13.json
@@ -1,0 +1,28 @@
+{
+  "version": 13,
+  "appVolumes": {},
+  "appSettings": {
+    "defaultNewAppVolume": 1.0,
+    "launchAtLogin": false,
+    "menuBarIconStyle": "Monochrome",
+    "lockInputDevice": true,
+    "showDeviceDisconnectAlerts": true,
+    "loudnessCompensationEnabled": false,
+    "loudnessEqualizationEnabled": false,
+    "mediaKeyControlEnabled": true,
+    "hudStyle": "tahoe"
+  },
+  "deviceVolumeTierOverride": {
+    "uid-usb-interface": "software",
+    "uid-external-display": "ddc"
+  },
+  "softwareDeviceVolumes": {
+    "uid-usb-interface": 0.6
+  },
+  "softwareDeviceMuteStates": {
+    "uid-usb-interface": false
+  },
+  "softwareDeviceSavedVolumes": {
+    "uid-usb-interface": 0.6
+  }
+}

--- a/FineTuneTests/MenuBarIconStateTests.swift
+++ b/FineTuneTests/MenuBarIconStateTests.swift
@@ -221,6 +221,35 @@ struct NonSpeakerBaselineTests {
     }
 }
 
+@Suite("MenuBarIconState.baseline — Monochrome style (static speaker)")
+struct MonochromeBaselineTests {
+
+    @Test("Unmuted at any volume shows speaker.fill (no wave bars)")
+    func monochromeUnmutedShowsStaticSpeaker() {
+        let expected = MenuBarIconState.staticBaseline(.systemSymbol("speaker.fill"))
+        for v in [Float(0.0), 0.25, 0.5, 0.75, 1.0] {
+            #expect(MenuBarIconState.baseline(style: .monochrome, volume: v, muted: false) == expected, "volume=\(v)")
+        }
+    }
+
+    @Test("Muted shows speaker.slash.fill")
+    func monochromeMutedShowsSlash() {
+        for v in [Float(0.0), 0.5, 1.0] {
+            let state = MenuBarIconState.baseline(style: .monochrome, volume: v, muted: true)
+            #expect(state == .speakerMuted, "volume=\(v)")
+        }
+    }
+
+    @Test("Monochrome ignores volume (always shows filled speaker when unmuted)")
+    func monochromeIgnoresVolume() {
+        let expected = MenuBarIconState.staticBaseline(.systemSymbol("speaker.fill"))
+        let state1 = MenuBarIconState.baseline(style: .monochrome, volume: 0.0, muted: false)
+        let state2 = MenuBarIconState.baseline(style: .monochrome, volume: 1.0, muted: false)
+        #expect(state1 == expected)
+        #expect(state2 == expected)
+    }
+}
+
 @Suite("MenuBarIconState — consistency with MenuBarIconStyle.iconName")
 struct StyleIconNameConsistencyTests {
 
@@ -250,5 +279,11 @@ struct StyleIconNameConsistencyTests {
     func deviceMatchesDefaultIconName() {
         let baseline = MenuBarIconState.baseline(style: .device, volume: 0.5, muted: false)
         #expect(baseline.image == .systemSymbol(MenuBarIconStyle.device.iconName))
+    }
+
+    @Test(".monochrome baseline image matches MenuBarIconStyle.monochrome.iconName")
+    func monochromeMatches() {
+        let baseline = MenuBarIconState.baseline(style: .monochrome, volume: 0.5, muted: false)
+        #expect(baseline.image == .systemSymbol(MenuBarIconStyle.monochrome.iconName))
     }
 }

--- a/FineTuneTests/UserEQPresetTests.swift
+++ b/FineTuneTests/UserEQPresetTests.swift
@@ -660,10 +660,10 @@ struct UserEQPresetPersistenceTests {
 @MainActor
 struct SettingsVersionTests {
 
-    @Test("Default Settings().version is 12")
+    @Test("Default Settings().version is 13")
     func defaultVersion() {
         let settings = SettingsManager.Settings()
-        #expect(settings.version == 12)
+        #expect(settings.version == 13)
     }
 
     @Test("userEQPresets defaults to empty array in Settings()")


### PR DESCRIPTION
## Feature Extension: New MenuBarIconStyle.monochrome

Adds a new `MenuBarIconStyle.monochrome` case for a minimalist, volume-independent menu bar icon.

### Changes

- **SettingsUITypes.swift** — Added `.monochrome = "Monochrome"` enum case with `speaker.fill` icon name
- **MenuBarIconState.swift** — `.monochrome` renders `speaker.fill` when unmuted and `.speakerMuted` when muted (static appearance at all volume levels)
- **SettingsManager.swift** — Bumped `Settings.version` from 12 → 13

### Settings Migration

- Old v12 settings files decode correctly (backward compatible)
- The new enum case is additive; no fields removed or renamed
- A `settings-v13.json` fixture was created

### Tests Added

- 3 new tests for monochrome style behavior
- 5 new tests for v12→v13 migration
- Updated version assertion from 12 → 13

### Risk Assessment

- **Settings schema**: Additive change (new enum case). No existing users break.
- **Core Audio**: No changes to audio engine, process taps, or routing.
- **Scope**: Self-contained menu bar icon rendering.